### PR TITLE
Fix admin schedule settings tab

### DIFF
--- a/frontend/src/components/AdminApp.jsx
+++ b/frontend/src/components/AdminApp.jsx
@@ -23,7 +23,7 @@ const AdminApp = () => {
       }
     };
 
-    if (activeTab === 'settings') {
+    if (activeTab === 'schedule-settings') {
         fetchSettings();
     }
   }, [activeTab]);
@@ -86,7 +86,7 @@ const AdminApp = () => {
             <button
               onClick={() => setActiveTab('schedule-settings')}
               className={`whitespace-nowrap pb-4 px-1 border-b-2 font-medium text-sm transition-colors ${
-                activeTab === 'settings'
+                activeTab === 'schedule-settings'
                   ? 'border-brand-accent text-brand-accent'
                   : 'border-transparent text-brand-secondary hover:text-brand-text hover:border-gray-300'
               }`}


### PR DESCRIPTION
## Summary
- fix effect condition in admin app for schedule settings
- ensure tab highlight uses the correct key

## Testing
- `CI=true npx react-scripts test --passWithNoTests`
- `CI=true npx jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68846f831fc08326b105ef62bc0d96d3