### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a problem to help us improve
+title: "[BUG] <summary>"
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+What actually happened when you performed the steps above.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+- OS: [e.g. Windows, macOS, Linux]
+- Browser: [e.g. Chrome, Safari]
+- Version: [e.g. 22]
+
+## Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest an improvement or new feature
+title: "[FEATURE] <summary>"
+labels: enhancement
+assignees: ''
+---
+
+## Description
+Describe the feature you would like to see.
+
+## Motivation
+Explain why this feature would be useful.
+
+## Proposed Solution
+If you have ideas on how to implement the feature, share them here.
+
+## Alternatives Considered
+List any alternative solutions or features you've considered.
+
+## Additional Context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## Summary
- add a simple bug report template
- add a feature request template

## Testing
- `CI=true npm test` *(fails: No tests found)*
- `CI=true npm run test:backend` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68846f938ec483268df88834932b5c9f