### PR TITLE
Fix timezone mismatch for booking slots

### DIFF
--- a/backend/routes/slots.js
+++ b/backend/routes/slots.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { Op } = require('sequelize');
-const { addDays, addMinutes, getDay, isAfter, isBefore, isEqual, isWithinInterval, parse, startOfDay } = require('date-fns');
+const { addDays, addMinutes, getDay, isAfter, isBefore, isEqual, isWithinInterval, parse, startOfDay, format } = require('date-fns');
 const logger = require('../config/logger');
 const authMiddleware = require('../middleware/authMiddleware');
 const ScheduleSetting = require('../models/ScheduleSetting');
@@ -126,13 +126,14 @@ router.get('/', async (req, res) => {
 
     logger.info(`Found ${availableSlots.length} available slots.`);
 
-    // Group slots by date for easier frontend consumption
+    // Group slots by date for easier frontend consumption.
+    // Use a timezone-agnostic key to avoid mismatches with the frontend.
     const groupedSlots = availableSlots.reduce((acc, slot) => {
-      const date = startOfDay(slot.slotTime).toISOString();
-      if (!acc[date]) {
-        acc[date] = [];
+      const dateKey = format(startOfDay(slot.slotTime), 'yyyy-MM-dd');
+      if (!acc[dateKey]) {
+        acc[dateKey] = [];
       }
-      acc[date].push(slot);
+      acc[dateKey].push(slot);
       return acc;
     }, {});
 

--- a/frontend/src/components/BookingForm.jsx
+++ b/frontend/src/components/BookingForm.jsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast';
 import api from '../api';
 import { DayPicker } from 'react-day-picker';
 import { FiCalendar } from 'react-icons/fi';
-import { format, isSameDay, startOfDay } from 'date-fns';
+import { format, isSameDay, startOfDay, parse } from 'date-fns';
 import { ru } from 'date-fns/locale';
 import 'react-day-picker/dist/style.css';
 
@@ -51,7 +51,9 @@ const BookingForm = () => {
     }
   }, [selectedSlot, setValue]);
 
-  const availableDates = Object.keys(slots).map(dateStr => new Date(dateStr));
+  const availableDates = Object.keys(slots).map(dateStr =>
+    parse(dateStr, 'yyyy-MM-dd', new Date())
+  );
 
   const isDateAvailable = (date) => {
     return availableDates.some(availableDate => isSameDay(date, availableDate));
@@ -68,7 +70,7 @@ const BookingForm = () => {
 
   const getTimeSlotsForDate = (date) => {
     if (!date) return [];
-    const dateKey = startOfDay(date).toISOString();
+    const dateKey = format(startOfDay(date), 'yyyy-MM-dd');
     return slots[dateKey] || [];
   };
 


### PR DESCRIPTION
## Summary
- fix date grouping in backend by using `yyyy-MM-dd`
- parse dates and match keys the same way in frontend

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fff66c788326b7599bc4843a713f