### PR TITLE
Implement bookings creation endpoint

### DIFF
--- a/backend/routes/bookings.js
+++ b/backend/routes/bookings.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const router = express.Router();
+const { body, validationResult } = require('express-validator');
 const authMiddleware = require('../middleware/authMiddleware');
 const Booking = require('../models/Booking');
+const AvailableSlot = require('../models/AvailableSlot');
 
 // @route   GET api/bookings
 // @desc    Get all bookings for the logged-in psychologist
@@ -19,6 +21,49 @@ router.get('/', authMiddleware, async (req, res) => {
   }
 });
 
-// More booking-related routes (POST, PUT, DELETE) will be added here later.
+// @route   POST api/bookings
+// @desc    Create a new booking based on selected slot
+// @access  Public
+router.post(
+  '/',
+  [
+    body('name').not().isEmpty().withMessage('Имя обязательно'),
+    body('email').isEmail().withMessage('Некорректный email'),
+    body('phone').optional().isString(),
+    body('slotId').not().isEmpty().withMessage('Не выбран слот'),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { name, email, phone, slotId } = req.body;
+
+    try {
+      const slot = await AvailableSlot.findByPk(slotId);
+      if (!slot || slot.isBooked) {
+        return res.status(400).json({ msg: 'Выбранный слот недоступен' });
+      }
+
+      const booking = await Booking.create({
+        clientName: name,
+        clientEmail: email,
+        clientPhone: phone,
+        slotTime: slot.slotTime,
+        endTime: slot.endTime,
+      });
+
+      await slot.update({ isBooked: true });
+
+      res.json(booking);
+    } catch (err) {
+      console.error(err.message);
+      res.status(500).send('Ошибка сервера');
+    }
+  }
+);
+
+// More booking-related routes (PUT, DELETE) will be added here later.
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add `AvailableSlot` import to booking routes
- implement POST `/api/bookings` for creating bookings

## Testing
- `cd frontend && CI=true npm test -- --passWithNoTests`
- `cd backend && CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6885c4d809b483269137f06f29388387