### PR TITLE
Add custom-styled admin calendar

### DIFF
--- a/frontend/src/components/AdminApp.jsx
+++ b/frontend/src/components/AdminApp.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import BookingsTab from './BookingsTab';
 import ScheduleSettingsTab from './ScheduleSettingsTab';
-// import CalendarTab from './CalendarTab'; // To be implemented later
+import CalendarTab from './CalendarTab';
 
 import api from '../api';
 import { toast } from 'react-hot-toast';
@@ -40,8 +40,8 @@ const AdminApp = () => {
         return <BookingsTab />;
       case 'schedule-settings':
         return <ScheduleSettingsTab />;
-      // case 'calendar':
-      //   return <CalendarTab />;
+      case 'calendar':
+        return <CalendarTab />;
       default:
         return <BookingsTab />;
     }
@@ -93,7 +93,7 @@ const AdminApp = () => {
             >
               Настройки расписания
             </button>
-            {/* <button
+            <button
               onClick={() => setActiveTab('calendar')}
               className={`whitespace-nowrap pb-4 px-1 border-b-2 font-medium text-sm transition-colors ${
                 activeTab === 'calendar'
@@ -102,7 +102,7 @@ const AdminApp = () => {
               }`}
             >
               Календарь
-            </button> */}
+            </button>
           </nav>
         </div>
 

--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -1,13 +1,162 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import {
+  startOfWeek,
+  addDays,
+  format,
+  startOfMonth,
+  endOfMonth,
+  endOfWeek,
+  addMonths,
+  subMonths,
+  isSameMonth,
+  isSameDay,
+} from 'date-fns';
+import ru from 'date-fns/locale/ru';
+import api from '../api';
+import '../styles/calendar.css';
+
+const BookingDetailsModal = ({ booking, onClose }) => {
+  if (!booking) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded-lg w-80 shadow-lg">
+        <h4 className="text-lg font-semibold mb-4">Детали записи</h4>
+        <p className="text-sm mb-1"><strong>Клиент:</strong> {booking.clientName}</p>
+        <p className="text-sm mb-1"><strong>Телефон:</strong> {booking.clientPhone || '—'}</p>
+        <p className="text-sm mb-4"><strong>Время:</strong> {format(booking.start, 'dd.MM.yyyy HH:mm')}</p>
+        <button
+          onClick={onClose}
+          className="mt-2 px-4 py-2 rounded-lg bg-brand-accent text-white text-sm font-medium"
+        >
+          Закрыть
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const CalendarTab = () => {
-  return (
-    <div className="bg-white rounded-2xl shadow-lg border border-gray-200/60 p-6">
-      <h3 className="text-xl font-semibold text-brand-text mb-6">Календарь записей</h3>
-      <div className="text-center py-16 border-2 border-dashed border-gray-200 rounded-xl">
-          <h4 className="mt-4 text-lg font-medium text-brand-text">Раздел в разработке</h4>
-          <p className="mt-1 text-sm text-brand-secondary">Здесь будет интерактивный календарь для управления записями.</p>
+  const [events, setEvents] = useState([]);
+  const [currentMonth, setCurrentMonth] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedEvent, setSelectedEvent] = useState(null);
+
+  useEffect(() => {
+    const fetchBookings = async () => {
+      try {
+        const response = await api.get('/bookings');
+        const bookings = response.data;
+        const mapped = bookings.map((b) => ({
+          id: b.id,
+          title: b.clientName,
+          start: new Date(b.slotTime),
+          end: new Date(b.endTime),
+          clientName: b.clientName,
+          clientPhone: b.clientPhone,
+        }));
+        setEvents(mapped);
+      } catch (err) {
+        console.error('Failed to fetch bookings', err);
+      }
+    };
+    fetchBookings();
+  }, []);
+
+  const monthStart = startOfMonth(currentMonth);
+  const monthEnd = endOfMonth(monthStart);
+  const startDate = startOfWeek(monthStart, { weekStartsOn: 1 });
+  const endDate = endOfWeek(monthEnd, { weekStartsOn: 1 });
+
+  const dateFormat = 'd';
+  const weeks = [];
+  let day = startDate;
+  let formattedDate = '';
+
+  while (day <= endDate) {
+    const days = [];
+    for (let i = 0; i < 7; i++) {
+      formattedDate = format(day, dateFormat, { locale: ru });
+      const cloneDay = day;
+      const dayEvents = events.filter((e) => isSameDay(e.start, cloneDay));
+      days.push(
+        <div
+          className={`calendar__day ${!isSameMonth(day, monthStart) ? 'inactive' : ''} ${isSameDay(day, selectedDate) ? 'today' : ''}`}
+          key={day}
+          onClick={() => setSelectedDate(cloneDay)}
+        >
+          <span className="calendar__date">{formattedDate}</span>
+          <span className={`calendar__task${isSameDay(day, selectedDate) ? ' calendar__task--today' : ''}`}>{dayEvents.length}</span>
         </div>
+      );
+      day = addDays(day, 1);
+    }
+    weeks.push(<section className="calendar__week" key={day}>{days}</section>);
+  }
+
+  const nextMonth = () => {
+    setCurrentMonth(addMonths(currentMonth, 1));
+  };
+
+  const prevMonth = () => {
+    setCurrentMonth(subMonths(currentMonth, 1));
+  };
+
+  const eventsForSelectedDate = events
+    .filter((e) => isSameDay(e.start, selectedDate))
+    .sort((a, b) => a.start - b.start);
+
+  return (
+    <div className="calendar-contain">
+      <section className="title-bar">
+        <button className="title-bar__burger" onClick={prevMonth}>
+          <span className="burger__lines">Prev</span>
+        </button>
+        <span className="title-bar__year">
+          {format(currentMonth, 'LLLL yyyy', { locale: ru })}
+        </span>
+        <span className="title-bar__month">Month</span>
+        <div className="title-bar__controls">
+          <div className="title-bar__minimize" onClick={nextMonth}></div>
+          <div className="title-bar__maximize"></div>
+          <div className="title-bar__close"></div>
+        </div>
+      </section>
+
+      <aside className="calendar__sidebar">
+        <h2 className="sidebar__heading">
+          {format(selectedDate, 'EEEE', { locale: ru })}
+          <br />
+          {format(selectedDate, 'd MMMM', { locale: ru })}
+        </h2>
+        <ul className="sidebar__list">
+          {eventsForSelectedDate.length === 0 && (
+            <li className="sidebar__list-item">Записей нет</li>
+          )}
+          {eventsForSelectedDate.map((evt) => (
+            <li
+              key={evt.id}
+              className="sidebar__list-item"
+              onClick={() => setSelectedEvent(evt)}
+            >
+              <span className="list-item__time">{format(evt.start, 'HH:mm')}</span>
+              {evt.title}
+            </li>
+          ))}
+        </ul>
+      </aside>
+
+      <section className="calendar__days">
+        <section className="calendar__top-bar">
+          {['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'].map((d) => (
+            <span key={d} className="top-bar__days">
+              {d}
+            </span>
+          ))}
+        </section>
+        {weeks}
+      </section>
+
+      <BookingDetailsModal booking={selectedEvent} onClose={() => setSelectedEvent(null)} />
     </div>
   );
 };

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -1,0 +1,353 @@
+
+.calendar-contain {
+  position: relative;
+  left: 0;
+  right: 0;
+  border-radius: 0;
+  width: 100%;
+  overflow: hidden;
+  max-width: 1020px;
+  min-width: 450px;
+  margin: 1rem auto;
+  background-color: #f5f7f6;
+  box-shadow: 5px 5px 72px rgba(30, 46, 50, 0.5);
+  color: #040605;
+}
+@media screen and (min-width: 55em) {
+  .calendar-contain {
+    margin: auto;
+    top: 5%;
+  }
+}
+
+.title-bar {
+  position: relative;
+  width: 100%;
+  display: table;
+  text-align: right;
+  background: #f5f7f6;
+  padding: 0.5rem;
+  margin-bottom: 0;
+}
+.title-bar:after {
+  display: table;
+  clear: both;
+}
+
+.title-bar__burger {
+  display: block;
+  position: relative;
+  float: left;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  width: 38px;
+  height: 30px;
+  font-size: 0;
+  text-indent: -9999px;
+  appearance: none;
+  box-shadow: none;
+  border-radius: none;
+  border: none;
+  cursor: pointer;
+  background: none;
+}
+.title-bar__burger:focus {
+  outline: none;
+}
+
+.burger__lines {
+  display: block;
+  position: absolute;
+  width: 18px;
+  top: 15px;
+  left: 0;
+  right: 0;
+  margin: auto;
+  height: 1px;
+  background: #040605;
+}
+.burger__lines:before, .burger__lines:after {
+  position: absolute;
+  display: block;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background-color: #040605;
+  content: "";
+}
+.burger__lines:before {
+  top: -5px;
+}
+.burger__lines:after {
+  bottom: -5px;
+}
+
+.title-bar__year {
+  display: block;
+  position: relative;
+  float: left;
+  font-size: 1rem;
+  line-height: 30px;
+  width: 43%;
+  padding: 0 0.5rem;
+  text-align: left;
+}
+@media screen and (min-width: 55em) {
+  .title-bar__year {
+    width: 27%;
+  }
+}
+
+.title-bar__month {
+  position: relative;
+  float: left;
+  font-size: 1rem;
+  line-height: 30px;
+  width: 22%;
+  padding: 0 0.5rem;
+  text-align: left;
+}
+@media screen and (min-width: 55em) {
+  .title-bar__month {
+    width: 12%;
+  }
+}
+.title-bar__month:after {
+  content: "";
+  display: inline;
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  right: 0;
+  top: 5px;
+  margin: auto;
+  border-top: 1px solid rgb(0, 0, 0);
+  border-right: 1px solid rgb(0, 0, 0);
+  transform: rotate(135deg);
+}
+
+.title-bar__minimize,
+.title-bar__maximize,
+.title-bar__close {
+  position: relative;
+  float: left;
+  width: 34px;
+  height: 34px;
+}
+.title-bar__minimize:before, .title-bar__minimize:after,
+.title-bar__maximize:before,
+.title-bar__maximize:after,
+.title-bar__close:before,
+.title-bar__close:after {
+  top: 30%;
+  right: 30%;
+  bottom: 30%;
+  left: 30%;
+  content: " ";
+  position: absolute;
+  border-color: #8e8e8e;
+  border-style: solid;
+  border-width: 0 0 2px 0;
+}
+
+.title-bar .title-bar__controls {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  float: right;
+  width: auto;
+}
+.title-bar .title-bar__controls:before, .title-bar .title-bar__controls:after {
+  content: none;
+}
+
+.title-bar .title-bar__minimize:before {
+  border-bottom-width: 2px;
+}
+
+.title-bar .title-bar__maximize:before {
+  border-width: 1px 1px 2px 1px;
+}
+
+.title-bar .title-bar__close:before,
+.title-bar .title-bar__close:after {
+  bottom: 50%;
+  top: 49.9%;
+}
+
+.title-bar .title-bar__close:before {
+  transform: rotate(45deg);
+}
+
+.title-bar .title-bar__close:after {
+  transform: rotate(-45deg);
+}
+
+.calendar__sidebar {
+  width: 100%;
+  margin: 0 auto;
+  float: none;
+  background: linear-gradient(120deg, rgb(239.4339622642, 242.5471698113, 243.0660377358), #e1e7e8);
+  padding-bottom: 0.7rem;
+}
+@media screen and (min-width: 55em) {
+  .calendar__sidebar {
+    position: absolute;
+    height: 100%;
+    width: 30%;
+    float: left;
+    margin-bottom: 0;
+  }
+}
+
+.calendar__sidebar .content {
+  padding: 2rem 1.5rem 2rem 4rem;
+  color: #040605;
+}
+
+.sidebar__nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin-bottom: 0.9rem;
+  padding: 0.7rem 1rem;
+  background-color: #f5f7f6;
+}
+
+.sidebar__nav-item {
+  display: inline-block;
+  width: 22px;
+  margin-right: 23px;
+  padding: 0;
+  opacity: 0.8;
+}
+
+.sidebar__list {
+  list-style: none;
+  margin: 0;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.sidebar__list-item {
+  margin: 1.2rem 0;
+  color: rgb(44.8, 67.2, 56);
+  font-weight: 100;
+  font-size: 1rem;
+}
+
+.list-item__time {
+  display: inline-block;
+  width: 60px;
+}
+@media screen and (min-width: 55em) {
+  .list-item__time {
+    margin-right: 2rem;
+  }
+}
+
+.sidebar__list-item--complete {
+  color: rgba(4, 6, 5, 0.3);
+}
+.sidebar__list-item--complete .list-item__time {
+  color: rgba(4, 6, 5, 0.3);
+}
+
+.sidebar__heading {
+  font-size: 2.2rem;
+  font-weight: bold;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  margin-bottom: 3rem;
+  margin-top: 1rem;
+}
+.sidebar__heading span {
+  float: right;
+  font-weight: 300;
+}
+
+.calendar__heading-highlight {
+  color: #2d444a;
+  font-weight: 900;
+}
+
+.calendar__days {
+  display: flex;
+  flex-flow: column wrap;
+  align-items: stretch;
+  width: 100%;
+  float: none;
+  min-height: 580px;
+  height: 100%;
+  font-size: 12px;
+  padding: 0.8rem 0 1rem 1rem;
+  background: #f5f7f6;
+}
+@media screen and (min-width: 55em) {
+  .calendar__days {
+    width: 70%;
+    float: right;
+  }
+}
+
+.calendar__top-bar {
+  display: flex;
+  flex: 32px 0 0;
+}
+
+.top-bar__days {
+  width: 100%;
+  padding: 0 5px;
+  color: rgb(44.8, 67.2, 56);
+  font-weight: 100;
+  -webkit-font-smoothing: subpixel-antialiased;
+  font-size: 1rem;
+}
+
+.calendar__week {
+  display: flex;
+  flex: 1 1 0;
+}
+
+.calendar__day {
+  display: flex;
+  flex-flow: column wrap;
+  justify-content: space-between;
+  width: 100%;
+  padding: 1.9rem 0.2rem 0.2rem;
+}
+
+.calendar__date {
+  color: #040605;
+  font-size: 1.7rem;
+  font-weight: 600;
+  line-height: 0.7;
+}
+@media screen and (min-width: 55em) {
+  .calendar__date {
+    font-size: 2.3rem;
+  }
+}
+
+.calendar__week .inactive .calendar__date,
+.calendar__week .inactive .task-count {
+  color: #c6c6c6;
+}
+.calendar__week .today .calendar__date {
+  color: #fd588a;
+}
+
+.calendar__task {
+  color: #040605;
+  display: flex;
+  font-size: 0.8rem;
+}
+@media screen and (min-width: 55em) {
+  .calendar__task {
+    font-size: 1rem;
+  }
+}
+.calendar__task.calendar__task--today {
+  color: #fd588a;
+}


### PR DESCRIPTION
## Summary
- enable calendar tab with custom design
- implement CalendarTab with CodePen-inspired layout
- add dedicated calendar.css for styling
- remove unused react-big-calendar styles import

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6885da26b4688326ae0c020ba691cb6f