### PR TITLE
Add calendar modal to booking form

### DIFF
--- a/frontend/src/components/BookingForm.jsx
+++ b/frontend/src/components/BookingForm.jsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast';
 import api from '../api';
 import { DayPicker } from 'react-day-picker';
 import { FiCalendar } from 'react-icons/fi';
+import CalendarModal from './CalendarModal';
 import { format, isSameDay, startOfDay, parse } from 'date-fns';
 import { ru } from 'date-fns/locale';
 import 'react-day-picker/dist/style.css';
@@ -40,6 +41,7 @@ const BookingForm = () => {
   const [selectedDate, setSelectedDate] = useState(undefined);
   const [selectedSlot, setSelectedSlot] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
 
   const { register, handleSubmit, formState: { errors }, reset, setValue } = useForm();
 
@@ -145,6 +147,7 @@ const BookingForm = () => {
   }
 
   return (
+    <>
     <div className="min-h-screen bg-brand-background flex items-center justify-center p-4 sm:p-6 lg:p-8">
       <div className="w-full max-w-5xl mx-auto bg-white rounded-2xl shadow-lg border border-gray-200/60 overflow-hidden">
         <div className="grid grid-cols-1 lg:grid-cols-2">
@@ -152,6 +155,13 @@ const BookingForm = () => {
           <div className="p-6 sm:p-8 border-r border-gray-200/60">
             <h2 className="text-xl font-bold text-brand-text mb-1">Запись на консультацию</h2>
             <p className="text-brand-secondary mb-6 text-sm">1. Выберите удобную дату и время</p>
+            <button
+              type="button"
+              onClick={() => setIsCalendarOpen(true)}
+              className="mb-4 flex items-center text-sm text-brand-accent hover:underline"
+            >
+              <FiCalendar className="mr-2" /> Открыть календарь
+            </button>
             <DayPicker
               mode="single"
               selected={selectedDate}
@@ -282,6 +292,8 @@ const BookingForm = () => {
         </div>
       </div>
     </div>
+    <CalendarModal isOpen={isCalendarOpen} onClose={() => setIsCalendarOpen(false)} />
+    </>
   );
 };
 

--- a/frontend/src/components/CalendarModal.jsx
+++ b/frontend/src/components/CalendarModal.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import CalendarTab from './CalendarTab';
+
+const CalendarModal = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="relative bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-full overflow-auto">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 text-2xl"
+          aria-label="Закрыть"
+        >
+          &times;
+        </button>
+        <CalendarTab />
+      </div>
+    </div>
+  );
+};
+
+export default CalendarModal;


### PR DESCRIPTION
## Summary
- add `CalendarModal` component to show `CalendarTab` in an overlay
- open modal from booking form via "Открыть календарь" button

## Testing
- `npm run test:frontend -- --watchAll=false`
- `npm run test:backend --if-present`

------
https://chatgpt.com/codex/tasks/task_e_6889e5ad5bd8832696ad77212351059f