### PR TITLE
Improve month navigation buttons

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { FiChevronLeft, FiChevronRight } from 'react-icons/fi';
 import {
   startOfWeek,
   addDays,
@@ -218,8 +219,12 @@ const CalendarTab = () => {
         </span>
         <span className="title-bar__month">Month</span>
         <div className="title-bar__controls">
-          <div className="title-bar__minimize" onClick={nextMonth}></div>
-          <div className="title-bar__maximize" onClick={prevMonth}></div>
+          <button className="month-prev" onClick={prevMonth}>
+            <FiChevronLeft />
+          </button>
+          <button className="month-next" onClick={nextMonth}>
+            <FiChevronRight />
+          </button>
           <div className="title-bar__close"></div>
         </div>
       </section>

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -162,6 +162,31 @@
   content: none;
 }
 
+.month-prev,
+.month-next {
+  position: relative;
+  float: left;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.month-prev svg,
+.month-next svg {
+  width: 20px;
+  height: 20px;
+}
+
+.month-prev:focus,
+.month-next:focus {
+  outline: none;
+}
+
 .title-bar .title-bar__minimize:before {
   border-bottom-width: 2px;
 }


### PR DESCRIPTION
## Summary
- use react-icons chevron buttons for navigating months
- style new nav buttons in calendar.css

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6889e5a4a84c8326804bee810475027d