### PR TITLE
Add month selector to calendar

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -8,12 +8,17 @@ import {
   endOfWeek,
   addMonths,
   subMonths,
+  setMonth,
   isSameMonth,
   isSameDay,
 } from 'date-fns';
 import ru from 'date-fns/locale/ru';
 import api from '../api';
 import '../styles/calendar.css';
+
+const months = Array.from({ length: 12 }, (_, i) =>
+  format(new Date(2020, i, 1), 'LLLL', { locale: ru })
+);
 
 const BookingDetailsModal = ({ booking, onClose }) => {
   if (!booking) return null;
@@ -216,7 +221,20 @@ const CalendarTab = () => {
         <span className="title-bar__year">
           {format(currentMonth, 'LLLL yyyy', { locale: ru })}
         </span>
-        <span className="title-bar__month">Month</span>
+        <span className="title-bar__month">
+          <select
+            value={currentMonth.getMonth()}
+            onChange={(e) =>
+              setCurrentMonth(setMonth(currentMonth, Number(e.target.value)))
+            }
+          >
+            {months.map((m, idx) => (
+              <option value={idx} key={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </span>
         <div className="title-bar__controls">
           <div className="title-bar__minimize" onClick={nextMonth}></div>
           <div className="title-bar__maximize" onClick={prevMonth}></div>

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -127,6 +127,20 @@
   transform: rotate(135deg);
 }
 
+.title-bar__month select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: 100%;
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
 .title-bar__minimize,
 .title-bar__maximize,
 .title-bar__close {


### PR DESCRIPTION
## Summary
- replace static month label with a select menu
- update calendar styles so select follows existing design

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e596c35483268e9773f103c1c538