### PR TITLE
Add close control for Calendar menu

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { FiChevronLeft, FiChevronRight } from 'react-icons/fi';
+import { FiChevronLeft, FiChevronRight, FiX } from 'react-icons/fi';
 import {
   startOfWeek,
   addDays,
@@ -317,8 +317,9 @@ const CalendarTab = () => {
             <button
               className="menu-close"
               onClick={() => setMenuOpen(false)}
+              aria-label="Close menu"
             >
-              ×
+              <FiX />
             </button>
             {/* Placeholder for upcoming menu */}
           </div>

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -392,7 +392,7 @@
 }
 
 .calendar-menu {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 220px;
@@ -409,7 +409,7 @@
 }
 
 .menu-backdrop {
-  position: absolute;
+  position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.3);
   z-index: 50;


### PR DESCRIPTION
## Summary
- add FiX icon button for closing the calendar menu
- overlay the calendar menu with fixed positioning

## Testing
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6889ed2cdda083269534de2d8317a0c1