### PR TITLE
Add month selector dropdown in CalendarTab

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -17,8 +17,9 @@ import ru from 'date-fns/locale/ru';
 import api from '../api';
 import '../styles/calendar.css';
 
+// Month names for the dropdown. Using a fixed year ensures correct locale formatting
 const months = Array.from({ length: 12 }, (_, i) =>
-  format(new Date(2020, i, 1), 'LLLL', { locale: ru })
+  format(new Date(2025, i, 1), 'LLLL', { locale: ru })
 );
 
 const BookingDetailsModal = ({ booking, onClose }) => {
@@ -220,7 +221,7 @@ const CalendarTab = () => {
           <span className="burger__lines">Menu</span>
         </button>
         <span className="title-bar__year">
-          {format(currentMonth, 'LLLL yyyy', { locale: ru })}
+          {format(currentMonth, 'yyyy', { locale: ru })}
         </span>
         <span className="title-bar__month">
           <select


### PR DESCRIPTION
## Summary
- update month list to use 2025 for locale formatting
- show only the year text and move month selection to a dropdown

## Testing
- `CI=true npm run test:frontend -- -- --passWithNoTests`
- `CI=true npm run test:backend -- -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6889ed2d59e08326aab0e9852bff25ce