### PR TITLE
Add month dropdown selector

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { FiChevronLeft, FiChevronRight, FiX } from 'react-icons/fi';
 import {
   startOfWeek,
@@ -117,6 +117,8 @@ const CalendarTab = () => {
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [slotModal, setSlotModal] = useState(null);
+  const [monthOpen, setMonthOpen] = useState(false);
+  const monthRef = useRef(null);
 
   const fetchBookings = async () => {
     try {
@@ -159,6 +161,16 @@ const CalendarTab = () => {
     fetchBookings();
     fetchSlots();
 
+  }, []);
+
+  useEffect(() => {
+    const handleClick = (e) => {
+      if (monthRef.current && !monthRef.current.contains(e.target)) {
+        setMonthOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
   const monthStart = startOfMonth(currentMonth);
@@ -204,6 +216,11 @@ const CalendarTab = () => {
     setCurrentMonth(subMonths(currentMonth, 1));
   };
 
+  const handleMonthSelect = (idx) => {
+    setCurrentMonth(setMonth(currentMonth, idx));
+    setMonthOpen(false);
+  };
+
   const eventsForSelectedDate = events
     .filter((e) => isSameDay(e.start, selectedDate))
     .sort((a, b) => a.start - b.start);
@@ -223,19 +240,21 @@ const CalendarTab = () => {
         <span className="title-bar__year">
           {format(currentMonth, 'yyyy', { locale: ru })}
         </span>
-        <span className="title-bar__month">
-          <select
-            value={currentMonth.getMonth()}
-            onChange={(e) =>
-              setCurrentMonth(setMonth(currentMonth, Number(e.target.value)))
-            }
+        <span className="title-bar__month" ref={monthRef}>
+          <button
+            type="button"
+            className="title-bar__month-button"
+            onClick={() => setMonthOpen((o) => !o)}
           >
+            {format(currentMonth, 'LLLL', { locale: ru })}
+          </button>
+          <ul className={`month-dropdown ${monthOpen ? 'open' : ''}`}>
             {months.map((m, idx) => (
-              <option value={idx} key={m}>
+              <li key={m} onClick={() => handleMonthSelect(idx)}>
                 {m}
-              </option>
+              </li>
             ))}
-          </select>
+          </ul>
         </span>
         <div className="title-bar__controls">
           <button

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -127,7 +127,7 @@
   transform: rotate(135deg);
 }
 
-.title-bar__month select {
+.title-bar__month-button {
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -139,6 +139,33 @@
   line-height: inherit;
   color: inherit;
   cursor: pointer;
+  text-align: left;
+}
+
+.month-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  background: #ffffff;
+  border: 1px solid #ccc;
+  transition: max-height 0.2s ease;
+  z-index: 10;
+}
+
+.month-dropdown.open {
+  max-height: 14rem;
+}
+
+.month-dropdown li {
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.month-dropdown li:hover {
+  background-color: #f0f0f0;
 }
 
 .title-bar__minimize,


### PR DESCRIPTION
## Summary
- add month dropdown logic in CalendarTab
- style dropdown in calendar.css

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac4d2f1788326873da35a3f16ea46