### PR TITLE
Add close control and overlay to calendar menu

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -316,24 +316,20 @@ const CalendarTab = () => {
         onCreated={refreshData}
       />
 
-      {menuOpen && (
-        <>
-          <div
-            className="menu-backdrop"
-            onClick={() => setMenuOpen(false)}
-          ></div>
-          <div className="calendar-menu">
-            <button
-              className="menu-close"
-              onClick={() => setMenuOpen(false)}
-              aria-label="Close menu"
-            >
-              <FiX />
-            </button>
-            {/* Placeholder for upcoming menu */}
-          </div>
-        </>
-      )}
+      <div
+        className="menu-backdrop"
+        onClick={() => setMenuOpen(false)}
+      ></div>
+      <div className="calendar-menu">
+        <button
+          className="menu-close"
+          onClick={() => setMenuOpen(false)}
+          aria-label="Close menu"
+        >
+          <FiX />
+        </button>
+        {/* Placeholder for upcoming menu */}
+      </div>
     </div>
   );
 };

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -401,18 +401,28 @@
   box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
   transform: translateX(-100%);
   transition: transform 0.3s ease;
+  pointer-events: none;
   z-index: 60;
 }
 
 .menu-open .calendar-menu {
   transform: translateX(0);
+  pointer-events: auto;
 }
 
 .menu-backdrop {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
   z-index: 50;
+}
+
+.menu-open .menu-backdrop {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .menu-close {


### PR DESCRIPTION
## Summary
- keep calendar sidebar elements mounted so they can animate
- add menu backdrop close handler and button
- fade menu overlay in/out with CSS transitions

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688ac4d369a083269c93d6c701cedf5b