### PR TITLE
Add prev/next month buttons

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -239,14 +239,14 @@ const CalendarTab = () => {
         </span>
         <div className="title-bar__controls">
           <button
-            className="title-bar__minimize"
+            className="month-prev"
             onClick={prevMonth}
             aria-label="Предыдущий месяц"
           >
             <FiChevronLeft />
           </button>
           <button
-            className="title-bar__maximize"
+            className="month-next"
             onClick={nextMonth}
             aria-label="Следующий месяц"
           >

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -141,17 +141,12 @@
   cursor: pointer;
 }
 
-.title-bar__minimize,
-.title-bar__maximize,
 .title-bar__close {
   position: relative;
   float: left;
   width: 34px;
   height: 34px;
 }
-.title-bar__minimize:before, .title-bar__minimize:after,
-.title-bar__maximize:before,
-.title-bar__maximize:after,
 .title-bar__close:before,
 .title-bar__close:after {
   top: 30%;
@@ -201,13 +196,6 @@
   outline: none;
 }
 
-.title-bar .title-bar__minimize:before {
-  border-bottom-width: 2px;
-}
-
-.title-bar .title-bar__maximize:before {
-  border-width: 1px 1px 2px 1px;
-}
 
 .title-bar .title-bar__close:before,
 .title-bar .title-bar__close:after {


### PR DESCRIPTION
## Summary
- replace min/max buttons with Prev/Next month controls
- remove obsolete minimize/maximize CSS rules

## Testing
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac4d5743883269a00b074906619c7