### PR TITLE
Add clientTelegram field

### DIFF
--- a/backend/migrations/20250901090000-add-client-telegram.js
+++ b/backend/migrations/20250901090000-add-client-telegram.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Bookings', 'clientTelegram', { type: Sequelize.STRING });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('Bookings', 'clientTelegram');
+  },
+};

--- a/backend/models/Booking.js
+++ b/backend/models/Booking.js
@@ -17,10 +17,14 @@ const Booking = sequelize.define('Booking', {
   },
   clientEmail: {
     type: DataTypes.STRING,
-    allowNull: true, 
+    allowNull: true,
     validate: {
       isEmail: true,
     },
+  },
+  clientTelegram: {
+    type: DataTypes.STRING,
+    allowNull: true,
   },
   slotTime: {
     type: DataTypes.DATE,


### PR DESCRIPTION
## Summary
- include `clientTelegram` field in Booking model
- add migration for `clientTelegram`

## Testing
- `cd backend && npm test -- --passWithNoTests`
- `npx sequelize-cli db:migrate` *(fails: Could not install `sequelize-cli`)*

------
https://chatgpt.com/codex/tasks/task_e_688c43d0f19483268fd5defc3cdaac05