### PR TITLE
Add clientTelegram field to bookings

### DIFF
--- a/backend/migrations/20250801000000-add-client-telegram.js
+++ b/backend/migrations/20250801000000-add-client-telegram.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Bookings', 'clientTelegram', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('Bookings', 'clientTelegram');
+  },
+};

--- a/backend/models/Booking.js
+++ b/backend/models/Booking.js
@@ -17,10 +17,14 @@ const Booking = sequelize.define('Booking', {
   },
   clientEmail: {
     type: DataTypes.STRING,
-    allowNull: true, 
+    allowNull: true,
     validate: {
       isEmail: true,
     },
+  },
+  clientTelegram: {
+    type: DataTypes.STRING,
+    allowNull: true,
   },
   slotTime: {
     type: DataTypes.DATE,

--- a/backend/routes/bookings.js
+++ b/backend/routes/bookings.js
@@ -30,6 +30,7 @@ router.post(
     body('name').not().isEmpty().withMessage('Имя обязательно'),
     body('email').isEmail().withMessage('Некорректный email'),
     body('phone').optional().isString(),
+    body('telegram').optional().isString(),
     body('slotId').not().isEmpty().withMessage('Не выбран слот'),
   ],
   async (req, res) => {
@@ -38,7 +39,7 @@ router.post(
       return res.status(400).json({ errors: errors.array() });
     }
 
-    const { name, email, phone, slotId } = req.body;
+    const { name, email, phone, telegram, slotId } = req.body;
 
     try {
       const slot = await AvailableSlot.findByPk(slotId);
@@ -50,6 +51,7 @@ router.post(
         clientName: name,
         clientEmail: email,
         clientPhone: phone,
+        clientTelegram: telegram,
         slotTime: slot.slotTime,
         endTime: slot.endTime,
       });


### PR DESCRIPTION
## Summary
- store Telegram username for bookings
- migrate database with clientTelegram column
- validate telegram field in booking requests

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688c43d332dc8326af9a640b60890ce2