### PR TITLE
Add Telegram input for booking form

### DIFF
--- a/frontend/src/components/BookingForm.jsx
+++ b/frontend/src/components/BookingForm.jsx
@@ -90,6 +90,7 @@ const BookingForm = () => {
         name: data.name,
         email: data.email,
         phone: data.phone,
+        telegram: data.telegram,
         comment: data.comment,
         slotId: selectedSlot.id,
       });
@@ -252,6 +253,22 @@ const BookingForm = () => {
                   className="w-full px-4 py-2.5 bg-white border border-gray-300/70 rounded-lg focus:border-brand-accent focus:ring-2 focus:ring-brand-accent/20 transition-colors text-sm text-brand-text placeholder-gray-400"
                   placeholder="+7 (999) 123-45-67"
                 />
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-brand-secondary mb-1.5">Telegram</label>
+                <input
+                  type="text"
+                  {...register('telegram', {
+                    pattern: {
+                      value: /^@\w{5,}$/,
+                      message: 'Некорректный Telegram username',
+                    },
+                  })}
+                  className="w-full px-4 py-2.5 bg-white border border-gray-300/70 rounded-lg focus:border-brand-accent focus:ring-2 focus:ring-brand-accent/20 transition-colors text-sm text-brand-text placeholder-gray-400"
+                  placeholder="@username"
+                />
+                {errors.telegram && <p className="mt-1 text-xs text-red-600">{errors.telegram.message}</p>}
               </div>
 
               <div>


### PR DESCRIPTION
## Summary
- update `BookingForm` to accept an optional Telegram username
- send telegram data when creating bookings

## Testing
- `cd frontend && CI=true npm test -- --passWithNoTests`
- `cd ../backend && npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688c43d5763c8326ba0d8a7de52815e5