### PR TITLE
Add Telegram username field for manual bookings

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -45,6 +45,7 @@ const BookingDetailsModal = ({ booking, onClose }) => {
 const AddBookingModal = ({ slot, onClose, onCreated }) => {
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
+  const [telegram, setTelegram] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -52,6 +53,7 @@ const AddBookingModal = ({ slot, onClose, onCreated }) => {
       await api.post('/bookings', {
         name,
         phone,
+        telegram,
         slotId: slot.id,
       });
       onCreated();
@@ -86,6 +88,13 @@ const AddBookingModal = ({ slot, onClose, onCreated }) => {
           placeholder="Телефон"
           value={phone}
           onChange={(e) => setPhone(e.target.value)}
+          className="border rounded px-2 py-1 text-sm"
+        />
+        <input
+          type="text"
+          placeholder="Telegram"
+          value={telegram}
+          onChange={(e) => setTelegram(e.target.value)}
           className="border rounded px-2 py-1 text-sm"
         />
         <div className="flex justify-end gap-2 mt-2">


### PR DESCRIPTION
## Summary
- update `AddBookingModal` state to handle Telegram username
- include Telegram username in API call
- add input for Telegram username to form

## Testing
- `npx jest --passWithNoTests` in `backend`
- `npx jest --passWithNoTests` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688c43d6c8f883268e2873cd25337826