### PR TITLE
Fix missing logger dependency in telegram lookup service

### DIFF
--- a/backend/__tests__/telegramLookup.test.js
+++ b/backend/__tests__/telegramLookup.test.js
@@ -1,0 +1,38 @@
+jest.mock('../config/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  http: jest.fn(),
+}));
+
+const logger = require('../config/logger');
+
+describe('telegramLookup service exports', () => {
+  let lookupByPhone;
+  let lookupByUsername;
+
+  beforeAll(() => {
+    ({ lookupByPhone, lookupByUsername } = require('../services/telegramLookup'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('exports lookupByPhone and lookupByUsername functions', () => {
+    expect(typeof lookupByPhone).toBe('function');
+    expect(typeof lookupByUsername).toBe('function');
+  });
+
+  test('lookupByPhone returns null when service is disabled', async () => {
+    const result = await lookupByPhone('+1234567890');
+    expect(result).toBeNull();
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  test('lookupByUsername returns null when service is disabled', async () => {
+    const result = await lookupByUsername('@someone');
+    expect(result).toBeNull();
+    expect(logger.info).toHaveBeenCalled();
+  });
+});

--- a/backend/services/telegramLookup.js
+++ b/backend/services/telegramLookup.js
@@ -1,5 +1,6 @@
 const { TelegramClient, Api } = require('telegram');
 const { StringSession } = require('telegram/sessions');
+const logger = require('../config/logger');
 
 const isTest = process.env.NODE_ENV === 'test';
 const apiIdRaw = process.env.TELEGRAM_API_ID;


### PR DESCRIPTION
## Summary
- require the shared logger inside the Telegram lookup service so logging calls use the configured transport
- add a focused Jest test for the lookup service that stubs the logger and verifies the exported functions remain available

## Testing
- NODE_ENV=test npx jest --runInBand --detectOpenHandles *(fails: pre-existing redirect expectation mismatches in telegram_auth.test.js and related suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4535f9008326936782bde3aa4cbd