### PR TITLE
Fix WhatsApp check logger import and add fallback test

### DIFF
--- a/backend/__tests__/whatsapp.test.js
+++ b/backend/__tests__/whatsapp.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+
+jest.mock('../middleware/practitionerScope', () => jest.fn((req, res, next) => next()));
+jest.mock('../services/whatsappCheck', () => ({
+  checkWhatsApp: jest.fn(),
+}));
+
+const { checkWhatsApp } = require('../services/whatsappCheck');
+const app = require('../app');
+
+describe('GET /api/whatsapp/check', () => {
+  it('returns fallback JSON when whatsapp check fails', async () => {
+    checkWhatsApp.mockRejectedValueOnce(new Error('service error'));
+
+    const response = await request(app)
+      .get('/api/whatsapp/check')
+      .query({ phone: '+1234567890' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ configured: true, valid: false });
+    expect(checkWhatsApp).toHaveBeenCalledWith('+1234567890');
+  });
+});

--- a/backend/routes/whatsapp.js
+++ b/backend/routes/whatsapp.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const logger = require('../config/logger');
 const { checkWhatsApp } = require('../services/whatsappCheck');
 
 // GET /api/whatsapp/check?phone=+7XXXXXXXXXX


### PR DESCRIPTION
## Summary
- add the missing logger import to the WhatsApp check route so the error handler can log without throwing
- add a Jest test that mocks the WhatsApp check service and ensures the route returns its fallback payload when the check fails

## Testing
- npm run test:backend *(fails: Bookings access protection test expects practitioner IDs to match)*
- npx jest __tests__/whatsapp.test.js


------
https://chatgpt.com/codex/tasks/task_e_68ce4c69dcf48326a163a5e15df76985