### PR TITLE
Merge booking reschedule flow with notifications

### DIFF
--- a/backend/__tests__/bookings.test.js
+++ b/backend/__tests__/bookings.test.js
@@ -1,6 +1,7 @@
 const request = require('supertest');
+const jwt = require('jsonwebtoken');
 const app = require('../app');
-const { Booking, AvailableSlot, Practitioner } = require('../models');
+const { Booking, AvailableSlot, Practitioner, Client } = require('../models');
 const sequelize = require('../config/database');
 
 // Mock external services to avoid network/env dependencies
@@ -13,14 +14,25 @@ jest.mock('../services/whatsappCheck', () => ({
   checkWhatsApp: jest.fn().mockResolvedValue({ configured: false }),
 }));
 
+jest.mock('../services/telegramBot', () => ({
+  notifyNewShortNoticeBooking: jest.fn().mockResolvedValue(true),
+  notifyPractitionerNewBooking: jest.fn().mockResolvedValue(true),
+  notifyBookingCreated: jest.fn().mockResolvedValue(true),
+  sendRescheduleNotification: jest.fn().mockResolvedValue(true),
+}));
+
+const { sendRescheduleNotification } = require('../services/telegramBot');
+
 beforeAll(async () => {
 
   await sequelize.sync({ force: true });
 });
 
 beforeEach(async () => {
+  jest.clearAllMocks();
   await Booking.destroy({ where: {} });
   await AvailableSlot.destroy({ where: {} });
+  await Client.destroy({ where: {} });
   await Practitioner.destroy({ where: {} });
   practitioner = await Practitioner.create({
     slug: 'test-psychologist',
@@ -34,6 +46,13 @@ afterAll(async () => {
 
 const isoAt = (date, time) => new Date(`${date}T${time}:00`).toISOString();
 let practitioner;
+const createAdminToken = (practitionerId) => jwt.sign({
+  user: {
+    id: 'admin-test',
+    role: 'admin',
+    practitionerId,
+  },
+}, process.env.JWT_SECRET || 'test-secret-key-for-testing', { expiresIn: '1h' });
 
 describe('POST /api/bookings (manual by time)', () => {
   test('creates booking with slotTime/endTime and auto-creates slot', async () => {
@@ -162,5 +181,79 @@ describe('POST /api/bookings (by existing slotId)', () => {
 
     const refreshed = await AvailableSlot.findByPk(slot.id);
     expect(refreshed.isBooked).toBe(true);
+  });
+});
+
+describe('PATCH /api/bookings/:id/reschedule', () => {
+  test('updates booking, frees previous slot and notifies client', async () => {
+    const now = Date.now();
+    const oldStart = new Date(now + 24 * 3600 * 1000);
+    const oldEnd = new Date(oldStart.getTime() + 60 * 60 * 1000);
+    const newStart = new Date(now + 48 * 3600 * 1000);
+    const newEnd = new Date(newStart.getTime() + 60 * 60 * 1000);
+
+    const oldSlot = await AvailableSlot.create({
+      practitionerId: practitioner.id,
+      slotTime: oldStart,
+      endTime: oldEnd,
+      isBooked: true,
+    });
+
+    const newSlot = await AvailableSlot.create({
+      practitionerId: practitioner.id,
+      slotTime: newStart,
+      endTime: newEnd,
+      isBooked: false,
+    });
+
+    const client = await Client.create({
+      tgUserId: '12345',
+      tgChatId: '67890',
+      tgUsername: 'reschedule_client',
+      practitionerId: practitioner.id,
+    });
+
+    const booking = await Booking.create({
+      clientName: 'Reschedule Test',
+      slotTime: oldStart,
+      endTime: oldEnd,
+      practitionerId: practitioner.id,
+      AvailableSlotId: oldSlot.id,
+      clientId: client.id,
+      clientConfirmation: 'confirmed',
+      reminderSentAt: new Date(),
+      reminder24hSentAt: new Date(),
+      reminder1hSentAt: new Date(),
+    });
+
+    const token = createAdminToken(practitioner.id);
+    const res = await request(app)
+      .patch(`/api/bookings/${booking.id}/reschedule`)
+      .set('x-auth-token', token)
+      .set('x-practitioner-id', practitioner.id)
+      .send({ slotId: newSlot.id })
+      .expect(200);
+
+    expect(res.body.id).toBe(booking.id);
+    expect(new Date(res.body.slotTime).toISOString()).toBe(newSlot.slotTime.toISOString());
+
+    const updated = await Booking.findByPk(booking.id);
+    expect(String(updated.AvailableSlotId)).toBe(String(newSlot.id));
+    expect(updated.clientConfirmation).toBe('pending');
+    expect(updated.reminderSentAt).toBeNull();
+    expect(updated.reminder24hSentAt).toBeNull();
+    expect(updated.reminder1hSentAt).toBeNull();
+
+    const freedOldSlot = await AvailableSlot.findByPk(oldSlot.id);
+    expect(freedOldSlot.isBooked).toBe(false);
+
+    const bookedNewSlot = await AvailableSlot.findByPk(newSlot.id);
+    expect(bookedNewSlot.isBooked).toBe(true);
+
+    expect(sendRescheduleNotification).toHaveBeenCalledTimes(1);
+    const [notifiedBooking, notifiedOldStart, notifiedOldEnd] = sendRescheduleNotification.mock.calls[0];
+    expect(String(notifiedBooking.id)).toBe(String(booking.id));
+    expect(new Date(notifiedOldStart).toISOString()).toBe(oldStart.toISOString());
+    expect(new Date(notifiedOldEnd).toISOString()).toBe(oldEnd.toISOString());
   });
 });

--- a/backend/middleware/practitionerScope.js
+++ b/backend/middleware/practitionerScope.js
@@ -56,37 +56,39 @@ module.exports = async function practitionerScope(req, res, next) {
         const decoded = jwt.verify(token, jwtSecret);
         const user = decoded && decoded.user;
         if (user && ['admin', 'super_admin'].includes(user.role)) {
-          // Public override via headers: if user is on public form and explicitly provided
-          // tenant headers, prefer them over admin token for this request only.
-          try {
-            const hdrId = req.header('x-practitioner-id');
-            const hdrSlug = req.header('x-practitioner-slug');
-            const hdrPublic = req.header('x-practitioner-public-slug');
-            let overrideId = null;
-            if (hdrId) {
-              const idVal = String(hdrId).trim();
-              const exists = await practitionerCache.getById(idVal);
-              overrideId = exists ? exists.id : null;
-              if (overrideId) {
-                logger.debug(`[scope] override via header x-practitioner-id=${hdrId} -> ${overrideId} (admin present)`);
-              } else {
-                logger.warn(`[scope] override via header x-practitioner-id=${hdrId} not found`);
+          if (!user.practitionerId) {
+            // Public override via headers: if user is on public form and explicitly provided
+            // tenant headers, prefer them over admin token for this request only.
+            try {
+              const hdrId = req.header('x-practitioner-id');
+              const hdrSlug = req.header('x-practitioner-slug');
+              const hdrPublic = req.header('x-practitioner-public-slug');
+              let overrideId = null;
+              if (hdrId) {
+                const idVal = String(hdrId).trim();
+                const exists = await practitionerCache.getById(idVal);
+                overrideId = exists ? exists.id : null;
+                if (overrideId) {
+                  logger.debug(`[scope] override via header x-practitioner-id=${hdrId} -> ${overrideId} (admin present)`);
+                } else {
+                  logger.warn(`[scope] override via header x-practitioner-id=${hdrId} not found`);
+                }
+              } else if (hdrSlug) {
+                const p = await practitionerCache.getBySlug(String(hdrSlug).trim());
+                overrideId = p ? p.id : null;
+                logger.debug(`[scope] override via header x-practitioner-slug=${hdrSlug} -> ${overrideId} (admin present)`);
+              } else if (hdrPublic) {
+                const p = await practitionerCache.getByPublicSlug(String(hdrPublic).trim());
+                overrideId = p ? p.id : null;
+                logger.debug(`[scope] override via header x-practitioner-public-slug=${hdrPublic} -> ${overrideId} (admin present)`);
               }
-            } else if (hdrSlug) {
-              const p = await practitionerCache.getBySlug(String(hdrSlug).trim());
-              overrideId = p ? p.id : null;
-              logger.debug(`[scope] override via header x-practitioner-slug=${hdrSlug} -> ${overrideId} (admin present)`);
-            } else if (hdrPublic) {
-              const p = await practitionerCache.getByPublicSlug(String(hdrPublic).trim());
-              overrideId = p ? p.id : null;
-              logger.debug(`[scope] override via header x-practitioner-public-slug=${hdrPublic} -> ${overrideId} (admin present)`);
+              if (overrideId) {
+                req.practitionerId = overrideId;
+                return next();
+              }
+            } catch (e) {
+              logger.warn(`[scope] override resolve error: ${e.message}`);
             }
-            if (overrideId) {
-              req.practitionerId = overrideId;
-              return next();
-            }
-          } catch (e) {
-            logger.warn(`[scope] override resolve error: ${e.message}`);
           }
 
           if (user.practitionerId) {

--- a/backend/routes/bookings.js
+++ b/backend/routes/bookings.js
@@ -7,7 +7,7 @@ const logger = require('../config/logger');
 const authMiddleware = require('../middleware/authMiddleware');
 const adminOnly = require('../middleware/adminOnly');
 const clientAuthMiddleware = require('../middleware/clientAuthMiddleware');
-const { notifyNewShortNoticeBooking, notifyPractitionerNewBooking, notifyBookingCreated } = require('../services/telegramBot');
+const { notifyNewShortNoticeBooking, notifyPractitionerNewBooking, notifyBookingCreated, sendRescheduleNotification } = require('../services/telegramBot');
 const { enqueueTelegramNotification } = require('../services/jobQueue');
 const { parseTimeInput, formatSlotTime } = require('../utils/timezone');
 const sequelize = require('../config/database');
@@ -477,15 +477,25 @@ router.patch('/:id/reschedule', authMiddleware, adminOnly, async (req, res) => {
   if (!slotId && (!slotTime || !endTime)) {
     return res.status(400).json({ msg: 'Нужно передать либо slotId, либо slotTime и endTime' });
   }
+
   const t = await sequelize.transaction();
   try {
     const where = { id };
     if (req.practitionerId) where.practitionerId = req.practitionerId;
-    const booking = await Booking.findOne({ where, transaction: t });
+    const booking = await Booking.findOne({
+      where,
+      transaction: t,
+      include: [{ model: Client, as: 'client' }],
+    });
     if (!booking) {
       await t.rollback();
       return res.status(404).json({ msg: 'Запись не найдена' });
     }
+
+    const oldSlotId = booking.AvailableSlotId ? String(booking.AvailableSlotId) : null;
+    const oldStart = booking.slotTime ? new Date(booking.slotTime) : null;
+    const oldEnd = booking.endTime ? new Date(booking.endTime) : null;
+    const effectivePractitionerId = req.practitionerId || booking.practitionerId || null;
 
     let newSlot = null;
     let start = null;
@@ -497,11 +507,11 @@ router.patch('/:id/reschedule', authMiddleware, adminOnly, async (req, res) => {
         await t.rollback();
         return res.status(400).json({ msg: 'Слот не найден' });
       }
-      if (req.practitionerId && String(newSlot.practitionerId) !== String(req.practitionerId)) {
+      if (effectivePractitionerId && String(newSlot.practitionerId) !== String(effectivePractitionerId)) {
         await t.rollback();
         return res.status(403).json({ msg: 'Нельзя использовать слот другого психолога' });
       }
-      if (newSlot.isBooked && String(newSlot.id) !== String(booking.AvailableSlotId)) {
+      if (newSlot.isBooked && (!oldSlotId || String(newSlot.id) !== oldSlotId)) {
         await t.rollback();
         return res.status(400).json({ msg: 'Слот уже забронирован' });
       }
@@ -514,44 +524,60 @@ router.patch('/:id/reschedule', authMiddleware, adminOnly, async (req, res) => {
         await t.rollback();
         return res.status(400).json({ msg: 'Некорректные дата/время' });
       }
+
       const slotWhere = { slotTime: start, endTime: end };
-      if (req.practitionerId) slotWhere.practitionerId = req.practitionerId;
+      if (effectivePractitionerId) slotWhere.practitionerId = effectivePractitionerId;
       newSlot = await AvailableSlot.findOne({ where: slotWhere, transaction: t });
       if (!newSlot) {
-        newSlot = await AvailableSlot.create({ slotTime: start, endTime: end, isBooked: false, practitionerId: req.practitionerId || null }, { transaction: t });
+        newSlot = await AvailableSlot.create(
+          { slotTime: start, endTime: end, isBooked: false, practitionerId: effectivePractitionerId },
+          { transaction: t }
+        );
       }
-      if (newSlot.isBooked && String(newSlot.id) !== String(booking.AvailableSlotId)) {
+      if (newSlot.isBooked && (!oldSlotId || String(newSlot.id) !== oldSlotId)) {
         await t.rollback();
         return res.status(400).json({ msg: 'Слот уже забронирован' });
       }
     }
 
-    // Free old slot if exists and different
-    if (booking.AvailableSlotId && String(booking.AvailableSlotId) !== String(newSlot.id)) {
-      const oldSlot = await AvailableSlot.findByPk(booking.AvailableSlotId, { transaction: t });
+    if (oldSlotId && oldSlotId !== String(newSlot.id)) {
+      const oldSlot = await AvailableSlot.findByPk(oldSlotId, { transaction: t });
       if (oldSlot) {
         oldSlot.isBooked = false;
         await oldSlot.save({ transaction: t });
       }
     }
 
-    // Assign new slot
     newSlot.isBooked = true;
     await newSlot.save({ transaction: t });
 
-    await booking.update({
-      slotTime: start,
-      endTime: end,
-      AvailableSlotId: newSlot.id,
-      clientConfirmation: 'pending',
-      reminderSentAt: null,
-      reminder24hSentAt: null,
-      reminder1hSentAt: null,
-    }, { transaction: t });
+    await booking.update(
+      {
+        slotTime: start,
+        endTime: end,
+        AvailableSlotId: newSlot.id,
+        clientConfirmation: 'pending',
+        reminderSentAt: null,
+        reminder24hSentAt: null,
+        reminder1hSentAt: null,
+      },
+      { transaction: t }
+    );
 
     await t.commit();
 
-    // Notify client to confirm new time and notify practitioner
+    try {
+      await booking.reload({ include: [{ model: Client, as: 'client' }] });
+    } catch (_) { /* ignore reload errors */ }
+
+    if (oldStart && oldEnd && booking.client && (booking.client.tgUserId || booking.client.tgChatId)) {
+      try {
+        await sendRescheduleNotification(booking, oldStart, oldEnd);
+      } catch (notifyErr) {
+        try { logger.warn(`Failed to send reschedule notification for booking ${booking.id}: ${notifyErr.message}`); } catch (_) {}
+      }
+    }
+
     try { await notifyNewShortNoticeBooking(booking); } catch (_) {}
     try { await notifyPractitionerNewBooking(booking); } catch (_) {}
 
@@ -687,100 +713,6 @@ router.post('/:id/send-confirmation', authMiddleware, adminOnly, async (req, res
   } catch (e) {
     logger.error('Error sending confirmation request:', e);
     return res.status(500).json({ msg: 'Ошибка при отправке запроса' });
-  }
-});
-
-// @route   PATCH api/bookings/:id/reschedule
-// @desc    Reschedule booking to a new slot with client notification
-// @access  Private (Admin only)
-router.patch('/:id/reschedule', authMiddleware, adminOnly, async (req, res) => {
-  try {
-    const bookingId = req.params.id;
-    const practitionerId = req.practitionerId;
-    const { slotId } = req.body;
-
-    if (!slotId) {
-      return res.status(400).json({ msg: 'Не указан новый слот (slotId)' });
-    }
-
-    const booking = await Booking.findOne({
-      where: { 
-        id: bookingId,
-        practitionerId: practitionerId 
-      },
-      include: [{ model: Client, as: 'client' }]
-    });
-
-    if (!booking) {
-      logger.warn(`Booking not found: ${bookingId} for practitioner ${practitionerId}`);
-      return res.status(404).json({ msg: 'Запись не найдена' });
-    }
-
-    // Find and validate the new slot
-    const newSlot = await AvailableSlot.findOne({
-      where: {
-        id: slotId,
-        practitionerId: practitionerId,
-        isBooked: false
-      }
-    });
-
-    if (!newSlot) {
-      return res.status(400).json({ msg: 'Выбранный слот недоступен' });
-    }
-
-    const oldStart = booking.slotTime;
-    const oldEnd = booking.endTime;
-
-    // Update booking with new times
-    await booking.update({
-      slotTime: newSlot.slotTime,
-      endTime: newSlot.endTime,
-      AvailableSlotId: newSlot.id
-    });
-
-    // Mark new slot as booked
-    await newSlot.update({ isBooked: true });
-
-    // Free up old slot if it exists
-    if (booking.AvailableSlotId && booking.AvailableSlotId !== slotId) {
-      try {
-        await AvailableSlot.update(
-          { isBooked: false },
-          { where: { id: booking.AvailableSlotId, practitionerId: practitionerId } }
-        );
-      } catch (e) {
-        logger.warn(`Could not free old slot ${booking.AvailableSlotId}: ${e.message}`);
-      }
-    }
-
-    // Send notification to client if they have telegram
-    if (booking.client && (booking.client.tgUserId || booking.client.tgChatId)) {
-      try {
-        const { sendRescheduleNotification } = require('../services/telegramBot');
-        await sendRescheduleNotification(booking, oldStart, oldEnd);
-        logger.info(`Reschedule notification sent for booking ${bookingId}`);
-      } catch (e) {
-        logger.warn(`Failed to send reschedule notification for booking ${bookingId}: ${e.message}`);
-      }
-    }
-
-    logger.info(`Booking ${bookingId} rescheduled from ${oldStart} to ${newSlot.slotTime}`);
-
-    return res.json({
-      ok: true,
-      msg: 'Запись успешно перенесена',
-      booking: {
-        id: booking.id,
-        slotTime: booking.slotTime,
-        endTime: booking.endTime,
-        clientName: booking.clientName
-      }
-    });
-
-  } catch (e) {
-    logger.error('Error rescheduling booking:', e);
-    return res.status(500).json({ msg: 'Ошибка при переносе записи' });
   }
 });
 


### PR DESCRIPTION
## Summary
- merge the duplicate booking reschedule handlers to keep the transactional safeguards while sending client reschedule notifications
- add a backend test that exercises the reschedule endpoint and asserts the reschedule notifier is invoked
- prevent admin tokens already bound to a practitioner from being overridden by request headers to maintain tenant scoping

## Testing
- npx jest --runInBand --detectOpenHandles

------
https://chatgpt.com/codex/tasks/task_e_68ce4c6957a08326b3c32a41e060b0d2