### PR TITLE
Use practitioner timezone in Google Calendar link

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psybooking-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "psybooking-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
@@ -16,6 +16,7 @@
         "cleave.js": "^1.6.0",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.2.0",
+        "luxon": "^3.4.4",
         "react": "^18.2.0",
         "react-big-calendar": "^1.12.2",
         "react-day-picker": "^8.10.0",

--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -70,21 +70,23 @@ const months = Array.from({ length: 12 }, (_, i) =>
   format(new Date(2025, i, 1), 'LLLL', { locale: ru })
 );
 
+const toGCalDate = (d) => {
+  const iso = new Date(d).toISOString();
+  // 2025-08-29T12:30:00.000Z -> 20250829T123000Z
+  return iso.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+};
+
+export const buildGoogleCalendarUrl = (booking, practitionerTimezone = 'Europe/Moscow') => {
+  if (!booking) return '';
+  const text = encodeURIComponent(`Сессия: ${booking.clientName}`);
+  const details = encodeURIComponent(`Телефон: ${booking.clientPhone || '—'}`);
+  const dates = `${toGCalDate(booking.start)}/${toGCalDate(booking.end)}`;
+  const timezone = encodeURIComponent(practitionerTimezone || 'Europe/Moscow');
+  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${text}&dates=${dates}&details=${details}&ctz=${timezone}`;
+};
+
 const BookingDetailsModal = ({ booking, onClose, practitionerTimezone, onUpdated, onReschedule }) => {
   if (!booking) return null;
-
-  const toGCalDate = (d) => {
-    const iso = new Date(d).toISOString();
-    // 2025-08-29T12:30:00.000Z -> 20250829T123000Z
-    return iso.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
-  };
-  const buildGoogleCalendarUrl = (b) => {
-    const text = encodeURIComponent(`Сессия: ${b.clientName}`);
-    const details = encodeURIComponent(`Телефон: ${b.clientPhone || '—'}`);
-    const dates = `${toGCalDate(b.start)}/${toGCalDate(b.end)}`;
-    const ctz = encodeURIComponent('Europe/Moscow');
-    return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${text}&dates=${dates}&details=${details}&ctz=${ctz}`;
-  };
 
   const handleCopyLink = async () => {
     try {
@@ -105,6 +107,18 @@ const BookingDetailsModal = ({ booking, onClose, practitionerTimezone, onUpdated
       onClose();
     } catch (e) {
       toast.error(e?.response?.data?.msg || 'Не удалось отменить запись');
+    }
+  };
+
+  const handleAddToCalendar = () => {
+    try {
+      const calendarUrl = buildGoogleCalendarUrl(booking, practitionerTimezone);
+      if (typeof window === 'undefined') {
+        throw new Error('no window');
+      }
+      window.open(calendarUrl, '_blank', 'noopener,noreferrer');
+    } catch (_) {
+      toast.error('Не удалось открыть Google Calendar');
     }
   };
 
@@ -171,6 +185,13 @@ const BookingDetailsModal = ({ booking, onClose, practitionerTimezone, onUpdated
             onClick={handleCopyLink}
             className="px-3 py-2 rounded-lg border text-sm bg-white hover:bg-gray-50"
           >Скопировать ссылку</button>
+          <button
+            onClick={handleAddToCalendar}
+            className="px-3 py-2 rounded-lg border text-sm bg-white hover:bg-gray-50 flex items-center justify-center gap-2"
+          >
+            <FiCalendar />
+            В Google Calendar
+          </button>
         </div>
 
         <div className="mt-4 flex justify-end gap-2">

--- a/frontend/src/components/__tests__/CalendarTab.test.jsx
+++ b/frontend/src/components/__tests__/CalendarTab.test.jsx
@@ -1,0 +1,30 @@
+jest.mock('../../api', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const { buildGoogleCalendarUrl } = require('../CalendarTab');
+
+describe('buildGoogleCalendarUrl', () => {
+  const booking = {
+    start: '2024-05-10T10:00:00Z',
+    end: '2024-05-10T11:00:00Z',
+    clientName: 'Иван Иванов',
+    clientPhone: '+79995552211',
+  };
+
+  it('включает таймзону психолога в ссылку Google Calendar', () => {
+    const url = buildGoogleCalendarUrl(booking, 'Asia/Almaty');
+    expect(url).toContain('ctz=Asia%2FAlmaty');
+    expect(url).toContain('dates=20240510T100000Z/20240510T110000Z');
+  });
+
+  it('использует Europe/Moscow по умолчанию при отсутствии таймзоны', () => {
+    const url = buildGoogleCalendarUrl(booking);
+    expect(url).toContain('ctz=Europe%2FMoscow');
+  });
+});


### PR DESCRIPTION
## Summary
- build Google Calendar URLs using the practitioner's timezone with a Europe/Moscow fallback
- add a Google Calendar action in the booking details modal and wire it to the updated helper
- cover the link builder with a unit test to ensure non-default timezones are respected

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d0c95b8bd48326b353aecd15b06e82