### PR TITLE
Pass practitioner timezone to calendar displays

### DIFF
--- a/frontend/src/components/CalendarTab.jsx
+++ b/frontend/src/components/CalendarTab.jsx
@@ -102,6 +102,7 @@ const CalendarTab = ({ practitionerTimezone = 'Europe/Moscow' }) => {
               slots={slotsForSelectedDate}
               loadingBookings={loadingBookings}
               loadingSlots={loadingSlots}
+              practitionerTimezone={practitionerTimezone}
               onCreateSlot={(date) => setCreateSlotOpen(date)}
               onManualBooking={(date) => setManualOpen(date)}
               onEventSelect={setSelectedEvent}
@@ -117,6 +118,7 @@ const CalendarTab = ({ practitionerTimezone = 'Europe/Moscow' }) => {
               eventsForSelectedDate={eventsForSelectedDate}
               slotsForSelectedDate={slotsForSelectedDate}
               gridLoading={gridLoading}
+              practitionerTimezone={practitionerTimezone}
               onCurrentMonthChange={setCurrentMonth}
               onViewModeChange={setViewMode}
               onDateSelect={setSelectedDate}

--- a/frontend/src/components/calendar/CalendarSidebar.jsx
+++ b/frontend/src/components/calendar/CalendarSidebar.jsx
@@ -4,6 +4,7 @@ import { ru } from 'date-fns/locale';
 
 import { getBookingStatusClass } from '../../utils/bookingStatus';
 import { getClientsFocusUrl } from '../../utils/calendar';
+import { SimpleTimeDisplay, TimeRangeDisplay } from '../TimezoneDisplay';
 
 const CalendarSidebar = ({
   selectedDate,
@@ -11,6 +12,7 @@ const CalendarSidebar = ({
   slots,
   loadingBookings,
   loadingSlots,
+  practitionerTimezone,
   onCreateSlot,
   onManualBooking,
   onEventSelect,
@@ -67,7 +69,23 @@ const CalendarSidebar = ({
               onClick={() => onEventSelect(event)}
             >
               <div className="text-sm font-medium">
-                <span className="font-mono">{format(event.start, 'HH:mm')}–{format(event.end, 'HH:mm')}</span> · {event.title}
+                {event.end ? (
+                  <TimeRangeDisplay
+                    startTime={event.start}
+                    endTime={event.end}
+                    practitionerTimezone={practitionerTimezone}
+                    isAdmin={true}
+                    className="font-mono"
+                  />
+                ) : (
+                  <SimpleTimeDisplay
+                    utcTime={event.start}
+                    practitionerTimezone={practitionerTimezone}
+                    isAdmin={true}
+                    className="font-mono"
+                  />
+                )}
+                {` · ${event.title}`}
               </div>
               {event.telegramHandle && (
                 <div className="text-xs mt-1">
@@ -107,7 +125,20 @@ const CalendarSidebar = ({
                 onClick={() => onSlotSelect(slot)}
               >
                 <span className="text-sm">
-                  {format(new Date(slot.slotTime), 'HH:mm')}–{format(new Date(slot.endTime), 'HH:mm')}
+                  {slot.endTime ? (
+                    <TimeRangeDisplay
+                      startTime={slot.slotTime}
+                      endTime={slot.endTime}
+                      practitionerTimezone={practitionerTimezone}
+                      isAdmin={true}
+                    />
+                  ) : (
+                    <SimpleTimeDisplay
+                      utcTime={slot.slotTime}
+                      practitionerTimezone={practitionerTimezone}
+                      isAdmin={true}
+                    />
+                  )}
                 </span>
                 <button
                   onClick={(event) => {

--- a/frontend/src/components/calendar/CalendarView.jsx
+++ b/frontend/src/components/calendar/CalendarView.jsx
@@ -27,6 +27,7 @@ const CalendarView = ({
   eventsForSelectedDate,
   slotsForSelectedDate,
   gridLoading,
+  practitionerTimezone,
   onCurrentMonthChange,
   onViewModeChange,
   onDateSelect,
@@ -185,7 +186,12 @@ const CalendarView = ({
                     onEventSelect(event);
                   }}
                 >
-                  <SimpleTimeDisplay utcTime={event.start} isAdmin={true} className="list-item__time inline" />
+                  <SimpleTimeDisplay
+                    utcTime={event.start}
+                    isAdmin={true}
+                    practitionerTimezone={practitionerTimezone}
+                    className="list-item__time inline"
+                  />
                   <ContactIcon method={event.preferredContact} />
                   <span className="list-item__title">{event.title}</span>
                 </li>
@@ -222,7 +228,12 @@ const CalendarView = ({
               )} contact-${event.preferredContact || 'phone'}`}
               onClick={() => onEventSelect(event)}
             >
-              <SimpleTimeDisplay utcTime={event.start} isAdmin={true} className="list-item__time inline" />
+              <SimpleTimeDisplay
+                utcTime={event.start}
+                isAdmin={true}
+                practitionerTimezone={practitionerTimezone}
+                className="list-item__time inline"
+              />
               <ContactIcon method={event.preferredContact} />
               <span className="list-item__title">{event.title}</span>
             </li>


### PR DESCRIPTION
## Summary
- pass the practitioner's timezone from the calendar container into the sidebar and grid
- ensure CalendarView uses the provided timezone when rendering booking times
- replace manual time formatting in CalendarSidebar with timezone-aware display components for events and slots

## Testing
- CI=true npm run test:frontend -- --watchAll=false *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d10430f4d88326b49147068bc93f45