### PR TITLE
Handle custom timezones in client selector

### DIFF
--- a/frontend/src/components/ClientTimezoneSelector.jsx
+++ b/frontend/src/components/ClientTimezoneSelector.jsx
@@ -1,7 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { FiMapPin, FiClock, FiCheck } from 'react-icons/fi';
+import React, { useState, useEffect, useRef } from 'react';
+import { FiMapPin, FiCheck } from 'react-icons/fi';
 import { TOP_CITIES, OTHER_CITIES, detectClosestRussianCity } from '../utils/russianCities';
 import CityTimezonePicker from './CityTimezonePicker';
+
+const MOSCOW_TIMEZONE = 'Europe/Moscow';
+const MOSCOW_CITY = TOP_CITIES.find(city => city.timezone === MOSCOW_TIMEZONE) || {
+  name: 'Москва',
+  timezone: MOSCOW_TIMEZONE
+};
 
 function getUtcOffsetDisplay(timezone) {
   if (!timezone) return '';
@@ -24,27 +30,43 @@ const ClientTimezoneSelector = ({
   const [showMoscowTime, setShowMoscowTime] = useState(false);
   const [detectedCity, setDetectedCity] = useState(null);
   const [selectedCity, setSelectedCity] = useState(null);
+  const [previousNonMoscowTimezone, setPreviousNonMoscowTimezone] = useState(null);
   const [autoCardDismissed, setAutoCardDismissed] = useState(false);
   const [isCityModalOpen, setIsCityModalOpen] = useState(false);
   const [now, setNow] = useState(new Date());
+  const moscowOverrideRef = useRef(false);
 
   useEffect(() => {
-    // Автоопределение города клиента
     const detected = detectClosestRussianCity();
     setDetectedCity(detected);
 
-    // Если timezone не установлен, используем автоопределение
     if (!selectedTimezone) {
-      setSelectedCity(detected);
-      onTimezoneChange(detected.timezone);
-      // Сразу не показываем синий блок, если автоопределение и так выбрано
+      if (detected?.timezone) {
+        setSelectedCity(() => ({ ...detected }));
+        setPreviousNonMoscowTimezone(detected.timezone);
+        onTimezoneChange(detected.timezone);
+        setAutoCardDismissed(true);
+      }
+      return;
+    }
+
+    if (selectedTimezone !== MOSCOW_TIMEZONE || !moscowOverrideRef.current) {
+      const allCities = [...TOP_CITIES, ...OTHER_CITIES];
+      const matchedCity = allCities.find(c => c.timezone === selectedTimezone);
+      const cityToSet = matchedCity ? { ...matchedCity } : { name: selectedTimezone, timezone: selectedTimezone };
+      setSelectedCity(prev => (prev?.timezone === selectedTimezone ? prev : cityToSet));
+    }
+
+    if (detected?.timezone && selectedTimezone === detected.timezone) {
       setAutoCardDismissed(true);
-    } else {
-      // Найти город по переданному timezone
-      const city = [...TOP_CITIES, ...OTHER_CITIES].find(c => c.timezone === selectedTimezone);
-      setSelectedCity(city || detected);
-      // Если исходно выбранная таймзона совпадает с автоопределённой — не показываем синий блок
-      try { if (selectedTimezone === detected.timezone) setAutoCardDismissed(true); } catch (_) {}
+    }
+
+    if (selectedTimezone !== MOSCOW_TIMEZONE || !moscowOverrideRef.current) {
+      setPreviousNonMoscowTimezone(selectedTimezone);
+    }
+
+    if (selectedTimezone !== MOSCOW_TIMEZONE && moscowOverrideRef.current) {
+      moscowOverrideRef.current = false;
     }
   }, [selectedTimezone, onTimezoneChange]);
 
@@ -57,13 +79,18 @@ const ClientTimezoneSelector = ({
   }, []);
 
   const handleCitySelect = (city) => {
-    setSelectedCity(city);
-    onTimezoneChange(city.timezone);
+    if (!city?.timezone) return;
+
+    const normalizedCity = { ...city };
+    setSelectedCity(normalizedCity);
+    setPreviousNonMoscowTimezone(normalizedCity.timezone);
+    moscowOverrideRef.current = false;
+    onTimezoneChange(normalizedCity.timezone);
     setIsOpen(false);
     setShowMoscowTime(false); // Сбрасываем тумблер МСК при выборе города
     // Если пользователь подтвердил автоопределённый город — скрываем информационную карточку
     try {
-      if (detectedCity && city && detectedCity.timezone === city.timezone) {
+      if (detectedCity && detectedCity.timezone === normalizedCity.timezone) {
         setAutoCardDismissed(true);
       }
     } catch (_) { /* ignore */ }
@@ -76,21 +103,33 @@ const ClientTimezoneSelector = ({
   };
 
   const toggleMoscowTime = () => {
-    setShowMoscowTime(!showMoscowTime);
-    if (!showMoscowTime) {
-      // Включаем показ по МСК - передаем московский timezone
-      onTimezoneChange('Europe/Moscow');
+    const nextValue = !showMoscowTime;
+
+    if (nextValue) {
+      const baseTimezone = selectedTimezone
+        || selectedCity?.timezone
+        || previousNonMoscowTimezone
+        || detectedCity?.timezone
+        || MOSCOW_TIMEZONE;
+
+      setPreviousNonMoscowTimezone(baseTimezone);
+      moscowOverrideRef.current = true;
+      onTimezoneChange(MOSCOW_TIMEZONE);
     } else {
-      // Возвращаем к определенному/выбранному городу
-      if (selectedCity) {
-        onTimezoneChange(selectedCity.timezone);
-      }
+      moscowOverrideRef.current = false;
+      const timezoneToRestore = previousNonMoscowTimezone
+        || selectedCity?.timezone
+        || detectedCity?.timezone
+        || MOSCOW_TIMEZONE;
+
+      onTimezoneChange(timezoneToRestore);
     }
+
+    setShowMoscowTime(nextValue);
   };
 
-  const currentDisplayCity = showMoscowTime 
-    ? TOP_CITIES.find(c => c.timezone === 'Europe/Moscow')
-    : selectedCity;
+  const currentDisplayCity = showMoscowTime ? MOSCOW_CITY : selectedCity;
+  const currentDisplayTimezone = showMoscowTime ? MOSCOW_TIMEZONE : selectedCity?.timezone;
   const isDetectedSelected = !!(detectedCity && selectedCity && !showMoscowTime && selectedCity.timezone === detectedCity.timezone);
 
   if (compact) {
@@ -102,7 +141,7 @@ const ClientTimezoneSelector = ({
         >
           <FiMapPin className="w-4 h-4" />
           <span>{currentDisplayCity?.name || 'Выбрать город'}</span>
-          <span className="text-xs">UTC{currentDisplayCity?.utcOffset}</span>
+          <span className="text-xs">{getUtcOffsetDisplay(currentDisplayTimezone)}</span>
         </button>
         
         {isOpen && (
@@ -117,7 +156,7 @@ const ClientTimezoneSelector = ({
                 className="w-full text-left p-2 hover:bg-gray-50 text-sm"
               >
                 <div className="font-medium">{city.name}</div>
-                <div className="text-xs text-gray-500">UTC{city.utcOffset}</div>
+                <div className="text-xs text-gray-500">{getUtcOffsetDisplay(city.timezone)}</div>
               </button>
             ))}
           </div>
@@ -137,7 +176,7 @@ const ClientTimezoneSelector = ({
               <div>
                 <h4 className="text-sm font-medium text-blue-800">Ваше время определено автоматически</h4>
                 <p className="text-sm text-blue-700 mt-1">
-                  Город: <strong>{detectedCity.name}</strong> (UTC{detectedCity.utcOffset})
+                  Город: <strong>{detectedCity.name}</strong> ({getUtcOffsetDisplay(detectedCity.timezone)})
                 </p>
                 <p className="text-xs text-blue-600 mt-1">
                   Текущее время: {now.toLocaleTimeString('ru-RU', { timeZone: detectedCity.timezone, hour12: false })}
@@ -165,7 +204,7 @@ const ClientTimezoneSelector = ({
       )}
 
       {/* Тумблер МСК */}
-      {showMoscowToggle && selectedCity?.timezone !== 'Europe/Moscow' && (
+      {showMoscowToggle && selectedCity?.timezone !== MOSCOW_TIMEZONE && (
         <div className="flex items-center gap-3">
           <label className="flex items-center cursor-pointer">
             <input
@@ -201,9 +240,9 @@ const ClientTimezoneSelector = ({
                 {currentDisplayCity?.name || 'Выберите город'}
               </div>
               <div className="text-sm text-gray-500">
-                {getUtcOffsetDisplay(showMoscowTime ? 'Europe/Moscow' : selectedCity?.timezone)} • {
+                {getUtcOffsetDisplay(currentDisplayTimezone)} • {
                   now.toLocaleTimeString('ru-RU', {
-                    timeZone: showMoscowTime ? 'Europe/Moscow' : selectedCity?.timezone,
+                    timeZone: currentDisplayTimezone || undefined,
                     hour12: false
                   })
                 }
@@ -251,7 +290,7 @@ const ClientTimezoneSelector = ({
                     <div className="flex items-center justify-between">
                       <div>
                         <div className="font-medium">{city.name}</div>
-                        <div className="text-sm text-gray-500">UTC{city.utcOffset}</div>
+                        <div className="text-sm text-gray-500">{getUtcOffsetDisplay(city.timezone)}</div>
                       </div>
                       {selectedCity?.timezone === city.timezone && (
                         <FiCheck className="text-brand-accent" />
@@ -278,7 +317,7 @@ const ClientTimezoneSelector = ({
                       <div className="flex items-center justify-between">
                         <div>
                           <div className="font-medium text-sm">{city.name}</div>
-                          <div className="text-xs text-gray-500">{city.region} • UTC{city.utcOffset}</div>
+                          <div className="text-xs text-gray-500">{city.region} • {getUtcOffsetDisplay(city.timezone)}</div>
                         </div>
                         {selectedCity?.timezone === city.timezone && (
                           <FiCheck className="text-brand-accent w-4 h-4" />

--- a/frontend/src/components/ClientTimezoneSelector.test.jsx
+++ b/frontend/src/components/ClientTimezoneSelector.test.jsx
@@ -1,0 +1,87 @@
+import React, { useCallback, useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ClientTimezoneSelector from './ClientTimezoneSelector';
+
+jest.mock('../utils/russianCities', () => {
+  const actual = jest.requireActual('../utils/russianCities');
+  return {
+    ...actual,
+    detectClosestRussianCity: jest.fn(() => actual.TOP_CITIES[0])
+  };
+});
+
+const getUtcLabel = (timezone) => {
+  const parts = new Intl.DateTimeFormat('ru-RU', { timeZone: timezone, timeZoneName: 'short' }).formatToParts(new Date());
+  const name = parts.find(part => part.type === 'timeZoneName')?.value || '';
+  return name.replace('GMT', 'UTC');
+};
+
+const getTimeString = (timezone) => new Date().toLocaleTimeString('ru-RU', { timeZone: timezone, hour12: false });
+
+describe('ClientTimezoneSelector', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const renderWithState = () => {
+    const changeLog = [];
+
+    const Wrapper = () => {
+      const [timezone, setTimezone] = useState('America/New_York');
+
+      const handleTimezoneChange = useCallback((newTimezone) => {
+        changeLog.push(newTimezone);
+        setTimezone(newTimezone);
+      }, []);
+
+      return (
+        <ClientTimezoneSelector
+          selectedTimezone={timezone}
+          onTimezoneChange={handleTimezoneChange}
+        />
+      );
+    };
+
+    render(<Wrapper />);
+    return { changeLog };
+  };
+
+  test('displays non-catalog timezone and restores it after toggling Moscow time', async () => {
+    const { changeLog } = renderWithState();
+
+    const baseLabel = await screen.findByText('America/New_York');
+    const timezoneButton = baseLabel.closest('button');
+    expect(timezoneButton).toBeTruthy();
+
+    const baseOffset = getUtcLabel('America/New_York');
+    const baseTime = getTimeString('America/New_York');
+
+    expect(within(timezoneButton).getByText((content) => content.startsWith(baseOffset))).toBeInTheDocument();
+    expect(within(timezoneButton).getByText((content) => content.includes(baseTime))).toBeInTheDocument();
+    expect(changeLog).toEqual([]);
+
+    const toggle = screen.getByLabelText('Показать время по Москве');
+    await userEvent.click(toggle);
+
+    expect(changeLog).toEqual(['Europe/Moscow']);
+
+    const moscowOffset = getUtcLabel('Europe/Moscow');
+    const moscowTime = getTimeString('Europe/Moscow');
+
+    expect(within(timezoneButton).getByText((content) => content.startsWith(moscowOffset))).toBeInTheDocument();
+    expect(within(timezoneButton).getByText((content) => content.includes(moscowTime))).toBeInTheDocument();
+
+    await userEvent.click(toggle);
+
+    expect(changeLog).toEqual(['Europe/Moscow', 'America/New_York']);
+    expect(within(timezoneButton).getByText('America/New_York')).toBeInTheDocument();
+    expect(within(timezoneButton).getByText((content) => content.startsWith(baseOffset))).toBeInTheDocument();
+    expect(within(timezoneButton).getByText((content) => content.includes(baseTime))).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure ClientTimezoneSelector preserves non-catalog timezones, tracks the previous selection, and toggles back from Moscow correctly
- compute and display UTC labels with Intl for all views, covering compact button, detection card, and dropdown lists
- add a regression test that exercises an America/New_York scenario and verifies toggle behavior

## Testing
- CI=true npm test -- ClientTimezoneSelector.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d1043473848326af4cf3eb383e0feb