### PR TITLE
Show timezone labels for booking time ranges

### DIFF
--- a/frontend/src/components/BookingForm.jsx
+++ b/frontend/src/components/BookingForm.jsx
@@ -14,7 +14,7 @@ import { ru } from 'date-fns/locale';
 import 'react-day-picker/dist/style.css';
 import { normalizePhoneForSubmit, isValidRuPhone } from '../utils/phoneFormat';
 import { FiCheckCircle } from 'react-icons/fi';
-import { TimeRangeDisplay, SimpleTimeDisplay } from './TimezoneDisplay';
+import { TimeRangeDisplay } from './TimezoneDisplay';
 
 const LoadingSpinner = () => (
   <div className="flex flex-col items-center justify-center p-10 bg-brand-background rounded-2xl">
@@ -348,7 +348,7 @@ const BookingForm = () => {
                       startTime={selectedSlot.slotTime}
                       endTime={selectedSlot.endTime}
                       isAdmin={false}
-                      className="inline"
+                      className="inline-flex flex-wrap items-center leading-tight"
                       clientTimezoneOverride={clientTimezone}
                     />
                   </div>
@@ -377,10 +377,11 @@ const BookingForm = () => {
                             : 'bg-white text-brand-text border-gray-300/80 hover:border-brand-accent hover:text-brand-accent'
                         }`}
                       >
-                        <SimpleTimeDisplay
-                          utcTime={slot.slotTime}
+                        <TimeRangeDisplay
+                          startTime={slot.slotTime}
+                          endTime={slot.endTime}
                           isAdmin={false}
-                          className="inline"
+                          className="inline-flex flex-col text-left"
                           clientTimezoneOverride={clientTimezone}
                         />
                       </button>
@@ -409,7 +410,7 @@ const BookingForm = () => {
                         startTime={nextAvailableSlot.slot.slotTime}
                         endTime={nextAvailableSlot.slot.endTime}
                         isAdmin={false}
-                        className="inline"
+                        className="inline-flex flex-wrap items-center leading-tight"
                         clientTimezoneOverride={clientTimezone}
                       />
                     </div>

--- a/frontend/src/components/TimezoneDisplay.jsx
+++ b/frontend/src/components/TimezoneDisplay.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
-import { format, parseISO } from 'date-fns';
-import { ru } from 'date-fns/locale';
+import { parseISO } from 'date-fns';
+import { getCityByTimezone } from '../utils/russianCities';
 
 /**
  * Простой компонент для отображения времени
@@ -124,9 +124,9 @@ export const SimpleTimeDisplay = ({
 /**
  * Компонент для отображения временного диапазона
  */
-export const TimeRangeDisplay = ({ 
-  startTime, 
-  endTime, 
+export const TimeRangeDisplay = ({
+  startTime,
+  endTime,
   practitionerTimezone = null,
   isAdmin = false,
   className = '',
@@ -181,12 +181,75 @@ export const TimeRangeDisplay = ({
   };
 
   const timeRange = formatTimeRange(startTime, endTime);
-  const showMoscowLabel = !isAdmin && timezone === 'Europe/Moscow';
+  const timezoneMeta = useMemo(() => {
+    if (!timezone) return null;
+    try {
+      return getCityByTimezone(timezone);
+    } catch (_) {
+      return null;
+    }
+  }, [timezone]);
+
+  const timezoneLabel = useMemo(() => {
+    if (!timezone) return '';
+
+    let offset = '';
+    try {
+      const parts = new Intl.DateTimeFormat('ru-RU', { timeZone: timezone, timeZoneName: 'short' }).formatToParts(new Date());
+      const shortName = parts.find(part => part.type === 'timeZoneName')?.value || '';
+      if (shortName) {
+        offset = shortName.replace('GMT', 'UTC');
+      }
+    } catch (_) {
+      /* ignore */
+    }
+
+    if (!offset && timezoneMeta?.utcOffset) {
+      offset = `UTC${timezoneMeta.utcOffset}`;
+    }
+
+    if (!offset) {
+      try {
+        const now = new Date();
+        const tzDate = new Date(now.toLocaleString('en-US', { timeZone: timezone }));
+        const diffMinutes = Math.round((tzDate.getTime() - now.getTime()) / 60000);
+        const sign = diffMinutes >= 0 ? '+' : '-';
+        const absMinutes = Math.abs(diffMinutes);
+        const hours = Math.floor(absMinutes / 60).toString();
+        const minutes = absMinutes % 60;
+        const minutePart = minutes ? `:${minutes.toString().padStart(2, '0')}` : '';
+        offset = `UTC${sign}${hours}${minutePart}`;
+      } catch (_) {
+        /* ignore */
+      }
+    }
+
+    let cityName = timezoneMeta?.name;
+    if (!cityName && timezone) {
+      try {
+        const parts = timezone.split('/');
+        cityName = parts[parts.length - 1]?.replace(/_/g, ' ') || '';
+      } catch (_) {
+        cityName = '';
+      }
+    }
+
+    const pieces = [offset, cityName].filter(Boolean);
+    if (pieces.length === 0) {
+      return timezone;
+    }
+
+    return pieces.join(' · ');
+  }, [timezone, timezoneMeta]);
 
   return (
-    <span className={className}>
-      {timeRange}
-      {showMoscowLabel && <span className="text-xs text-gray-500 ml-1">Все времена указаны по московскому времени (UTC+3)</span>}
+    <span className={['inline-flex flex-wrap gap-x-1 gap-y-0.5', className].filter(Boolean).join(' ')}>
+      <span className="leading-tight">{timeRange}</span>
+      {timezoneLabel && (
+        <span className="text-xs font-normal text-brand-secondary/80 leading-tight">
+          {timezoneLabel}
+        </span>
+      )}
     </span>
   );
 };


### PR DESCRIPTION
## Summary
- replace slot time display with time ranges that include the selected timezone in the booking form
- extend `TimeRangeDisplay` to append a UTC and city badge for any timezone override or practitioner zone

## Testing
- CI=true npm test -- --watchAll=false *(fails: buildGoogleCalendarUrl is not a function in CalendarTab.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d10444975c83269150eee2faa54a73