### PR TITLE
Improve timezone detection fallback handling

### DIFF
--- a/frontend/src/components/ClientTimezoneSelector.jsx
+++ b/frontend/src/components/ClientTimezoneSelector.jsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { FiMapPin, FiCheck } from 'react-icons/fi';
-import { TOP_CITIES, OTHER_CITIES, detectClosestRussianCity } from '../utils/russianCities';
+import {
+  TOP_CITIES,
+  OTHER_CITIES,
+  detectClosestRussianCity,
+  createTimezoneInfo,
+  getTimezoneOffsetInfo
+} from '../utils/russianCities';
 import CityTimezonePicker from './CityTimezonePicker';
 
 const MOSCOW_TIMEZONE = 'Europe/Moscow';
@@ -11,6 +17,12 @@ const MOSCOW_CITY = TOP_CITIES.find(city => city.timezone === MOSCOW_TIMEZONE) |
 
 function getUtcOffsetDisplay(timezone) {
   if (!timezone) return '';
+
+  const { formattedOffset } = getTimezoneOffsetInfo(timezone);
+  if (formattedOffset) {
+    return formattedOffset;
+  }
+
   try {
     const parts = new Intl.DateTimeFormat('ru-RU', { timeZone: timezone, timeZoneName: 'short' }).formatToParts(new Date());
     const name = parts.find(p => p.type === 'timeZoneName')?.value || '';
@@ -39,26 +51,20 @@ const ClientTimezoneSelector = ({
   useEffect(() => {
     const detected = detectClosestRussianCity();
     setDetectedCity(detected);
+  }, []);
 
+  useEffect(() => {
     if (!selectedTimezone) {
-      if (detected?.timezone) {
-        setSelectedCity(() => ({ ...detected }));
-        setPreviousNonMoscowTimezone(detected.timezone);
-        onTimezoneChange(detected.timezone);
-        setAutoCardDismissed(true);
+      setSelectedCity(null);
+      if (!moscowOverrideRef.current) {
+        setPreviousNonMoscowTimezone(null);
       }
       return;
     }
 
-    if (selectedTimezone !== MOSCOW_TIMEZONE || !moscowOverrideRef.current) {
-      const allCities = [...TOP_CITIES, ...OTHER_CITIES];
-      const matchedCity = allCities.find(c => c.timezone === selectedTimezone);
-      const cityToSet = matchedCity ? { ...matchedCity } : { name: selectedTimezone, timezone: selectedTimezone };
-      setSelectedCity(prev => (prev?.timezone === selectedTimezone ? prev : cityToSet));
-    }
-
-    if (detected?.timezone && selectedTimezone === detected.timezone) {
-      setAutoCardDismissed(true);
+    const normalizedCity = createTimezoneInfo(selectedTimezone);
+    if (normalizedCity) {
+      setSelectedCity(prev => (prev?.timezone === selectedTimezone ? prev : normalizedCity));
     }
 
     if (selectedTimezone !== MOSCOW_TIMEZONE || !moscowOverrideRef.current) {
@@ -68,7 +74,13 @@ const ClientTimezoneSelector = ({
     if (selectedTimezone !== MOSCOW_TIMEZONE && moscowOverrideRef.current) {
       moscowOverrideRef.current = false;
     }
-  }, [selectedTimezone, onTimezoneChange]);
+  }, [selectedTimezone]);
+
+  useEffect(() => {
+    if (detectedCity?.timezone && selectedTimezone === detectedCity.timezone) {
+      setAutoCardDismissed(true);
+    }
+  }, [detectedCity, selectedTimezone]);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
@@ -81,7 +93,9 @@ const ClientTimezoneSelector = ({
   const handleCitySelect = (city) => {
     if (!city?.timezone) return;
 
-    const normalizedCity = { ...city };
+    const normalizedCity = createTimezoneInfo(city.timezone);
+    if (!normalizedCity) return;
+
     setSelectedCity(normalizedCity);
     setPreviousNonMoscowTimezone(normalizedCity.timezone);
     moscowOverrideRef.current = false;
@@ -176,7 +190,11 @@ const ClientTimezoneSelector = ({
               <div>
                 <h4 className="text-sm font-medium text-blue-800">Ваше время определено автоматически</h4>
                 <p className="text-sm text-blue-700 mt-1">
-                  Город: <strong>{detectedCity.name}</strong> ({getUtcOffsetDisplay(detectedCity.timezone)})
+                  {detectedCity.isFallback ? (
+                    <>Часовой пояс: <strong>{detectedCity.name}</strong></>
+                  ) : (
+                    <>Город: <strong>{detectedCity.name}</strong> ({getUtcOffsetDisplay(detectedCity.timezone)})</>
+                  )}
                 </p>
                 <p className="text-xs text-blue-600 mt-1">
                   Текущее время: {now.toLocaleTimeString('ru-RU', { timeZone: detectedCity.timezone, hour12: false })}

--- a/frontend/src/components/ClientTimezoneSelector.test.jsx
+++ b/frontend/src/components/ClientTimezoneSelector.test.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ClientTimezoneSelector from './ClientTimezoneSelector';
+import { getTimezoneOffsetInfo } from '../utils/russianCities';
 
 jest.mock('../utils/russianCities', () => {
   const actual = jest.requireActual('../utils/russianCities');
@@ -12,6 +13,11 @@ jest.mock('../utils/russianCities', () => {
 });
 
 const getUtcLabel = (timezone) => {
+  const { formattedOffset } = getTimezoneOffsetInfo(timezone);
+  if (formattedOffset) {
+    return formattedOffset;
+  }
+
   const parts = new Intl.DateTimeFormat('ru-RU', { timeZone: timezone, timeZoneName: 'short' }).formatToParts(new Date());
   const name = parts.find(part => part.type === 'timeZoneName')?.value || '';
   return name.replace('GMT', 'UTC');
@@ -55,7 +61,7 @@ describe('ClientTimezoneSelector', () => {
   test('displays non-catalog timezone and restores it after toggling Moscow time', async () => {
     const { changeLog } = renderWithState();
 
-    const baseLabel = await screen.findByText('America/New_York');
+    const baseLabel = await screen.findByText('America/New_York (UTC−05:00)');
     const timezoneButton = baseLabel.closest('button');
     expect(timezoneButton).toBeTruthy();
 
@@ -80,7 +86,7 @@ describe('ClientTimezoneSelector', () => {
     await userEvent.click(toggle);
 
     expect(changeLog).toEqual(['Europe/Moscow', 'America/New_York']);
-    expect(within(timezoneButton).getByText('America/New_York')).toBeInTheDocument();
+    expect(within(timezoneButton).getByText('America/New_York (UTC−05:00)')).toBeInTheDocument();
     expect(within(timezoneButton).getByText((content) => content.startsWith(baseOffset))).toBeInTheDocument();
     expect(within(timezoneButton).getByText((content) => content.includes(baseTime))).toBeInTheDocument();
   });

--- a/frontend/src/utils/russianCities.js
+++ b/frontend/src/utils/russianCities.js
@@ -98,42 +98,168 @@ export const getCityByTimezone = (timezone) => {
   return RUSSIAN_CITIES.find(city => city.timezone === timezone);
 };
 
+const MINUS_SIGN = '\u2212';
+
+const parseOffsetFromTimeZoneName = (value) => {
+  if (!value) return null;
+  if (/^(GMT|UTC)$/.test(value)) {
+    return 0;
+  }
+
+  const match = value.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/);
+  if (!match) return null;
+
+  const sign = match[1] === '-' ? -1 : 1;
+  const hours = parseInt(match[2], 10);
+  const minutes = match[3] ? parseInt(match[3], 10) : 0;
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    return null;
+  }
+
+  return sign * (hours * 60 + minutes);
+};
+
+const resolveOffsetMinutes = (timezone, option) => {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      timeZoneName: option
+    });
+    const parts = formatter.formatToParts(new Date());
+    const namePart = parts.find(part => part.type === 'timeZoneName');
+    return parseOffsetFromTimeZoneName(namePart?.value);
+  } catch (_) {
+    return null;
+  }
+};
+
+const computeOffsetMinutes = (timezone) => {
+  if (!timezone) return null;
+
+  const options = ['shortOffset', 'short'];
+  for (const option of options) {
+    const minutes = resolveOffsetMinutes(timezone, option);
+    if (minutes !== null) {
+      return minutes;
+    }
+  }
+
+  try {
+    const now = new Date();
+    const localeString = now.toLocaleString('en-US', { timeZone: timezone });
+    const tzDate = new Date(localeString);
+    if (!Number.isNaN(tzDate.getTime())) {
+      return Math.round((tzDate.getTime() - now.getTime()) / 60000);
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+};
+
+const formatOffsetMinutes = (offsetMinutes) => {
+  if (typeof offsetMinutes !== 'number' || Number.isNaN(offsetMinutes)) {
+    return '';
+  }
+
+  const sign = offsetMinutes < 0 ? MINUS_SIGN : '+';
+  const absMinutes = Math.abs(offsetMinutes);
+  const hours = String(Math.floor(absMinutes / 60)).padStart(2, '0');
+  const minutes = String(absMinutes % 60).padStart(2, '0');
+
+  return `UTC${sign}${hours}:${minutes}`;
+};
+
+export const getTimezoneOffsetInfo = (timezone) => {
+  const offsetMinutes = computeOffsetMinutes(timezone);
+  const formattedOffset = formatOffsetMinutes(offsetMinutes);
+
+  return {
+    offsetMinutes,
+    formattedOffset
+  };
+};
+
+const getFallbackName = (timezone, formattedOffset) => {
+  if (!timezone) return '';
+  return formattedOffset ? `${timezone} (${formattedOffset})` : timezone;
+};
+
+export const createTimezoneInfo = (timezone) => {
+  if (!timezone) return null;
+
+  const city = getCityByTimezone(timezone);
+  const { offsetMinutes, formattedOffset } = getTimezoneOffsetInfo(timezone);
+
+  if (city) {
+    return {
+      ...city,
+      timezone,
+      isFallback: false,
+      formattedUtcOffset: formattedOffset,
+      offsetMinutes
+    };
+  }
+
+  const normalizedOffset = formattedOffset ? formattedOffset.replace('UTC', '').trim() : null;
+
+  return {
+    name: getFallbackName(timezone, formattedOffset),
+    timezone,
+    region: null,
+    utcOffset: normalizedOffset,
+    formattedUtcOffset: formattedOffset,
+    offsetMinutes,
+    isFallback: true,
+    originalTimezone: timezone
+  };
+};
+
 // Получить локализованное имя часового пояса
 export const getTimezoneLabel = (timezone) => {
-  const city = getCityByTimezone(timezone);
-  if (city) {
-    return `${city.name} (UTC${city.utcOffset})`;
+  const info = createTimezoneInfo(timezone);
+  if (!info) {
+    return timezone || '';
   }
-  return timezone;
+
+  if (info.isFallback) {
+    return info.name;
+  }
+
+  const offset = info.utcOffset
+    || (info.formattedUtcOffset ? info.formattedUtcOffset.replace('UTC', '').trim() : '');
+
+  return offset ? `${info.name} (UTC${offset})` : info.name;
 };
 
 // Автоопределение ближайшего российского города по timezone браузера
 export const detectClosestRussianCity = () => {
   try {
     const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    
+    const timezone = browserTimezone || 'UTC';
+
     // Сначала точное совпадение
-    const exactMatch = RUSSIAN_CITIES.find(city => city.timezone === browserTimezone);
-    if (exactMatch) return exactMatch;
-    
-    // Если точного совпадения нет, попробуем по UTC offset
-    const now = new Date();
-    const browserOffset = -now.getTimezoneOffset() / 60; // В часах
-    
-    const offsetMatches = RUSSIAN_CITIES.filter(city => {
-      const cityOffset = parseInt(city.utcOffset.replace('+', ''));
-      return cityOffset === browserOffset;
-    });
-    
-    if (offsetMatches.length > 0) {
-      // Предпочитаем крупные города
-      const topCityMatch = offsetMatches.find(city => TOP_CITIES.includes(city));
-      return topCityMatch || offsetMatches[0];
+    const exactMatch = RUSSIAN_CITIES.find(city => city.timezone === timezone);
+    if (exactMatch) return createTimezoneInfo(exactMatch.timezone);
+
+    const { offsetMinutes: browserOffsetMinutes } = getTimezoneOffsetInfo(timezone);
+
+    if (typeof browserOffsetMinutes === 'number') {
+      const offsetMatches = RUSSIAN_CITIES.filter(city => {
+        const { offsetMinutes } = getTimezoneOffsetInfo(city.timezone);
+        return typeof offsetMinutes === 'number' && offsetMinutes === browserOffsetMinutes;
+      });
+
+      if (offsetMatches.length > 0) {
+        const topCityMatch = offsetMatches.find(city => TOP_CITIES.includes(city));
+        const chosenCity = topCityMatch || offsetMatches[0];
+        return createTimezoneInfo(chosenCity.timezone);
+      }
     }
-    
-    // По умолчанию Москва
-    return RUSSIAN_CITIES[0]; // Москва
+
+    return createTimezoneInfo(timezone);
   } catch (e) {
-    return RUSSIAN_CITIES[0]; // Москва по умолчанию
+    return createTimezoneInfo('UTC');
   }
 };


### PR DESCRIPTION
## Summary
- add a universal timezone helper that computes offsets with Intl and returns fallback metadata when no Russian city matches
- update the client timezone selector to require manual confirmation, display the detected timezone card, and surface fallback labels
- adjust the component test to expect the new fallback formatting

## Testing
- CI=1 npm test -- --runTestsByPath src/components/ClientTimezoneSelector.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d146cc835c83269cf51346b341023e